### PR TITLE
191 implement `PurchasePresenter` and revamp `IPurchasePresenter` and fix `PurchasePresenterMock`

### DIFF
--- a/src/main/java/Application/ShoppingService.java
+++ b/src/main/java/Application/ShoppingService.java
@@ -157,7 +157,7 @@ public class ShoppingService{
     }
 
     
-    public Response<Boolean> makeBid(String auctionId, String sessionToken, float price) {
+    public Response<Boolean> makeBid(String sessionToken, String auctionId, float price) {
         if (!tokenService.validateToken(sessionToken)) {
             return Response.error("Invalid token");
         }

--- a/src/main/java/UI/presenters/IPurchasePresenter.java
+++ b/src/main/java/UI/presenters/IPurchasePresenter.java
@@ -1,5 +1,6 @@
 package UI.presenters;
 
+import java.util.Date;
 import java.util.Set;
 import Application.DTOs.OrderDTO;
 import Application.utils.Response;
@@ -13,39 +14,39 @@ public interface IPurchasePresenter {
      * Adds a specified quantity of a product to the user's cart.
      *
      * @param sessionToken the token representing the current authenticated user session
-     * @param productName the name of the product
-     * @param storeName the name of the store selling the product
-     * @param amount the quantity to add
-     * @return a {@link Response} indicating whether the product was successfully added
+     * @param productId the unique identifier of the product
+     * @param storeId the unique identifier of the store selling the product
+     * @param amount the quantity of the product to add
+     * @return a {@link Response} indicating whether the product was successfully added to the cart
      */
-    Response<Boolean> addProductToCart(String sessionToken, String productName, String storeName, int amount);
+    Response<Boolean> addProductToCart(String sessionToken, String productId, String storeId, int amount);
 
     /**
      * Completely removes a product from the user's cart.
      *
      * @param sessionToken the token representing the current authenticated user session
-     * @param productName the name of the product
-     * @param storeName the name of the store
-     * @return a {@link Response} indicating whether the product was successfully removed
+     * @param productId the unique identifier of the product
+     * @param storeId the unique identifier of the store selling the product
+     * @return a {@link Response} indicating whether the product was successfully removed from the cart
      */
-    Response<Boolean> removeProductFromCart(String sessionToken, String productName, String storeName);
+    Response<Boolean> removeProductFromCart(String sessionToken, String productId, String storeId);
 
     /**
-     * Removes a specific amount of a product from the cart.
+     * Removes a specific quantity of a product from the user's cart.
      *
      * @param sessionToken the token representing the current authenticated user session
-     * @param productName the name of the product
-     * @param storeName the name of the store
-     * @param amount the number of items to remove
-     * @return a {@link Response} indicating whether the specified quantity was removed
+     * @param productId the unique identifier of the product
+     * @param storeId the unique identifier of the store selling the product
+     * @param amount the quantity of the product to remove
+     * @return a {@link Response} indicating whether the specified quantity was successfully removed from the cart
      */
-    Response<Boolean> removeProductFromCart(String sessionToken, String productName, String storeName, int amount);
+    Response<Boolean> removeProductFromCart(String sessionToken, String productId, String storeId, int amount);
 
     /**
      * Displays the current contents of the user's cart.
      *
      * @param sessionToken the token representing the current authenticated user session
-     * @return a {@link Response} containing a set of {@link OrderDTO} representing the cart contents
+     * @return a {@link Response} containing a set of {@link OrderDTO} representing the items in the cart
      */
     Response<Set<OrderDTO>> viewCart(String sessionToken);
 
@@ -53,7 +54,7 @@ public interface IPurchasePresenter {
      * Empties the entire cart.
      *
      * @param sessionToken the token representing the current authenticated user session
-     * @return a {@link Response} indicating whether the cart was cleared successfully
+     * @return a {@link Response} indicating whether the cart was successfully cleared
      */
     Response<Boolean> clearCart(String sessionToken);
 
@@ -61,32 +62,33 @@ public interface IPurchasePresenter {
      * Clears the basket of a specific store within the user's cart.
      *
      * @param sessionToken the token representing the current authenticated user session
-     * @param storeName the name of the store
-     * @return a {@link Response} indicating whether the basket was cleared successfully
+     * @param storeId the unique identifier of the store whose basket is to be cleared
+     * @return a {@link Response} indicating whether the basket was successfully cleared
      */
-    Response<Boolean> clearBasket(String sessionToken, String storeName);
+    Response<Boolean> clearBasket(String sessionToken, String storeId);
 
     /**
      * Submits a bid for an auctioned product.
      *
      * @param sessionToken the token representing the current authenticated user session
-     * @param productName the name of the product
-     * @param storeName the store running the auction
-     * @param bidAmount the bid value
+     * @param auctionId the unique identifier of the auction
+     * @param bid the value of the bid being placed
      * @return a {@link Response} indicating whether the bid was successfully placed
      */
-    Response<Boolean> makeBid(String sessionToken, String productName, String storeName, double bidAmount);
+    Response<Boolean> makeBid(String sessionToken, String auctionId, float bid);
 
     /**
-     * Finalizes the purchase of the entire cart using provided payment and shipping details.
+     * Finalizes the purchase of the entire cart using the provided payment and shipping details.
      *
      * @param sessionToken the token representing the current authenticated user session
-     * @param paymentMethod the name of the payment method (e.g., "credit card")
-     * @param address the shipping address
-     * @param creditCardNumber the credit card number
-     * @param expirationDate the card's expiration date in MM/YY format
-     * @param cvv the CVV security code
-     * @return a {@link Response} indicating whether the purchase was successful
+     * @param cardNumber the credit card number used for payment
+     * @param expiryDate the expiration date of the credit card
+     * @param cvv the CVV security code of the credit card
+     * @param andIncrement an increment value for tracking or processing purposes
+     * @param clientName the name of the client making the purchase
+     * @param deliveryAddress the address where the purchased items will be delivered
+     * @return a {@link Response} indicating whether the purchase was successfully completed
      */
-    Response<Boolean> purchaseCart(String sessionToken, String paymentMethod, String address, String creditCardNumber, String expirationDate, String cvv);
+    Response<Boolean> purchaseCart(String sessionToken, String cardNumber, Date expiryDate, String cvv, long andIncrement,
+         String clientName, String deliveryAddress);
 }

--- a/src/main/java/UI/presenters/PurchasePresenter.java
+++ b/src/main/java/UI/presenters/PurchasePresenter.java
@@ -1,0 +1,61 @@
+package UI.presenters;
+
+import java.util.Date;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import Application.ShoppingService;
+import Application.DTOs.OrderDTO;
+import Application.utils.Response;
+
+@Component
+public class PurchasePresenter implements IPurchasePresenter {
+    private final ShoppingService shoppingService;
+
+    public PurchasePresenter(ShoppingService shoppingService) {
+        this.shoppingService = shoppingService;
+    }
+
+    @Override
+    public Response<Boolean> addProductToCart(String sessionToken, String productId, String storeId, int amount) {
+        return this.shoppingService.addProductToCart(sessionToken, productId, storeId, amount);
+    }
+
+    @Override
+    public Response<Boolean> removeProductFromCart(String sessionToken, String productId, String storeId) {
+        return this.shoppingService.removeProductFromCart(sessionToken, productId, storeId);
+    }
+
+    @Override
+    public Response<Boolean> removeProductFromCart(String sessionToken, String productId, String storeId, int amount) {
+        return this.shoppingService.removeProductFromCart(sessionToken, productId, storeId, amount);
+    }
+
+    @Override
+    public Response<Set<OrderDTO>> viewCart(String sessionToken) {
+        return this.shoppingService.viewCart(sessionToken);
+    }
+
+    @Override
+    public Response<Boolean> clearCart(String sessionToken) {
+        return this.shoppingService.clearCart(sessionToken);
+    }
+
+    @Override
+    public Response<Boolean> clearBasket(String sessionToken, String storeId) {
+        return this.shoppingService.clearBasket(sessionToken, storeId);
+    }
+
+    @Override
+    public Response<Boolean> makeBid(String sessionToken, String auctionId, float bid) {
+        return this.shoppingService.makeBid(sessionToken, auctionId, bid);
+    }
+
+    @Override
+    public Response<Boolean> purchaseCart(String sessionToken, String cardNumber, Date expiryDate, String cvv, long andIncrement,
+         String clientName, String deliveryAddress) {
+        return this.shoppingService.checkout(sessionToken, cardNumber, expiryDate, cvv, andIncrement, clientName, deliveryAddress);
+    }
+    
+}

--- a/src/main/java/UI/presenters/PurchasePresenterMock.java
+++ b/src/main/java/UI/presenters/PurchasePresenterMock.java
@@ -1,6 +1,7 @@
 package UI.presenters;
 
 import Application.DTOs.OrderDTO;
+import Application.utils.Response;
 import Domain.Store.Category;
 import org.springframework.stereotype.Component;
 
@@ -11,15 +12,8 @@ import java.util.stream.Collectors;
 @Component
 public class PurchasePresenterMock implements IPurchasePresenter {
 
-    // Map to store user carts: sessionToken -> List of OrderDTOs
     private final Map<String, Set<OrderDTO>> userCarts = new ConcurrentHashMap<>();
-    
-    // Known session tokens from LoginPresenterMock
-    private static final String GUEST_TOKEN = "guest-token";
-    private static final String REGISTERED_TOKEN = "fake-session-token";
-    private static final String LOGIN_TOKEN = "mock-session-token";
 
-    // Create mock categories for use in orders
     private final Set<Category> electronicsCategories = Set.of(
             new Category("Electronics", "Electronic devices and gadgets"),
             new Category("Tech", "Technology products")
@@ -35,189 +29,131 @@ public class PurchasePresenterMock implements IPurchasePresenter {
             new Category("Kitchen", "Kitchen appliances and tools")
     );
 
-    // Default cart data to be used for all users
     private final Set<OrderDTO> defaultCartItems;
 
     public PurchasePresenterMock() {
-        // Initialize with mock data for easier testing
-        defaultCartItems = new HashSet<>();
-        defaultCartItems.add(new OrderDTO("Smartphone", "Latest model smartphone", electronicsCategories, "TechStore", 1));
-        defaultCartItems.add(new OrderDTO("Bluetooth Speaker", "Wireless speaker with great sound", electronicsCategories, "TechStore", 2));
-        defaultCartItems.add(new OrderDTO("T-Shirt", "Cotton T-shirt, size M", clothingCategories, "ClothingShop", 3));
-        defaultCartItems.add(new OrderDTO("Jeans", "Blue denim jeans, size 32", clothingCategories, "ClothingShop", 1));
-        defaultCartItems.add(new OrderDTO("Coffee Maker", "Automatic coffee machine", homeCategories, "HomeGoods", 1));
-        defaultCartItems.add(new OrderDTO("Toaster", "4-slice toaster", homeCategories, "HomeGoods", 1));
-
-        // Initialize carts for the known tokens
-        Set<OrderDTO> guestCart = new HashSet<>(defaultCartItems);
-        userCarts.put(GUEST_TOKEN, guestCart);
-        
-        Set<OrderDTO> registeredCart = new HashSet<>(defaultCartItems);
-        // Add some special items for registered users
-        registeredCart.add(new OrderDTO("Premium Headphones", "High-quality wireless headphones", 
-                electronicsCategories, "TechStore", 1));
-        userCarts.put(REGISTERED_TOKEN, registeredCart);
-        
-        Set<OrderDTO> loginCart = new HashSet<>(defaultCartItems);
-        // Add some special items for logged-in users
-        loginCart.add(new OrderDTO("Smart Watch", "Latest smartwatch model", 
-                electronicsCategories, "TechStore", 1));
-        userCarts.put(LOGIN_TOKEN, loginCart);
+        defaultCartItems = Set.of(
+            new OrderDTO("prod1", "Smartphone", electronicsCategories, "TechStore", 1),
+            new OrderDTO("prod2", "Speaker", electronicsCategories, "TechStore", 2),
+            new OrderDTO("prod3", "T-Shirt", clothingCategories, "ClothingShop", 3),
+            new OrderDTO("prod4", "Jeans", clothingCategories, "ClothingShop", 1),
+            new OrderDTO("prod5", "Coffee Maker", homeCategories, "HomeGoods", 1),
+            new OrderDTO("prod6", "Toaster", homeCategories, "HomeGoods", 1)
+        );
     }
 
     @Override
-    public boolean addProductToCart(String sessionToken, String productName, String storeName, int amount) {
-        // Create cart for the session if it doesn't exist
+    public Response<Boolean> addProductToCart(String sessionToken, String productId, String storeId, int amount) {
         ensureCartExists(sessionToken);
         Set<OrderDTO> cart = userCarts.get(sessionToken);
 
-        // Check if product already exists in the cart
-        Optional<OrderDTO> existingProduct = cart.stream()
-                .filter(order -> order.getName().equals(productName) && order.getStoreName().equals(storeName))
+        Optional<OrderDTO> existing = cart.stream()
+                .filter(o -> o.getStoreName().equals(storeId))
                 .findFirst();
 
-        if (existingProduct.isPresent()) {
-            // Remove existing product
-            cart.remove(existingProduct.get());
-            // Add updated quantity (existing + new)
-            OrderDTO updatedOrder = new OrderDTO(
-                    productName,
-                    existingProduct.get().getCategories().stream().anyMatch(c -> c.getName().equals("Electronics")) ? 
-                        "Electronic device" : (existingProduct.get().getCategories().stream().anyMatch(c -> c.getName().equals("Clothing")) ?
-                        "Clothing item" : "Home item"),
-                    existingProduct.get().getCategories(),
-                    storeName,
-                    existingProduct.get().getQuantity() + amount
+        if (existing.isPresent()) {
+            cart.remove(existing.get());
+            OrderDTO updated = new OrderDTO(
+                    productId,
+                    existing.get().getName(),
+                    existing.get().getCategories(),
+                    storeId,
+                    existing.get().getQuantity() + amount
             );
-            cart.add(updatedOrder);
+            cart.add(updated);
         } else {
-            // Add new product
-            Set<Category> categories = electronicsCategories; // Default category
-            String description = "Electronic device";
-            
-            if (productName.toLowerCase().contains("shirt") || productName.toLowerCase().contains("jeans")) {
-                categories = clothingCategories;
-                description = "Clothing item";
-            } else if (productName.toLowerCase().contains("coffee") || productName.toLowerCase().contains("toaster")) {
-                categories = homeCategories;
-                description = "Home item";
-            }
-            
-            OrderDTO newOrder = new OrderDTO(productName, description, categories, storeName, amount);
-            cart.add(newOrder);
+            // Add new with fake category and name for simplicity
+            Set<Category> categories = productId.contains("3") ? clothingCategories :
+                    productId.contains("5") ? homeCategories : electronicsCategories;
+            String name = "Mock Product " + productId;
+            cart.add(new OrderDTO(productId, name, categories, storeId, amount));
         }
-        
-        return true;
+
+        return new Response<>(true);
     }
 
     @Override
-    public boolean removeProductFromCart(String sessionToken, String productName, String storeName) {
+    public Response<Boolean> removeProductFromCart(String sessionToken, String productId, String storeId) {
         ensureCartExists(sessionToken);
         Set<OrderDTO> cart = userCarts.get(sessionToken);
-        
-        int initialSize = cart.size();
-        cart.removeIf(order -> order.getName().equals(productName) && order.getStoreName().equals(storeName));
-        
-        return cart.size() < initialSize;
+        boolean removed = cart.removeIf(o -> o.getStoreName().equals(storeId));
+        return new Response<>(removed);
     }
 
     @Override
-    public boolean removeProductFromCart(String sessionToken, String productName, String storeName, int amount) {
+    public Response<Boolean> removeProductFromCart(String sessionToken, String productId, String storeId, int amount) {
         ensureCartExists(sessionToken);
         Set<OrderDTO> cart = userCarts.get(sessionToken);
-        
-        Optional<OrderDTO> existingProduct = cart.stream()
-                .filter(order -> order.getName().equals(productName) && order.getStoreName().equals(storeName))
+
+        Optional<OrderDTO> existing = cart.stream()
+                .filter(o ->o.getStoreName().equals(storeId))
                 .findFirst();
-                
-        if (existingProduct.isPresent()) {
-            OrderDTO order = existingProduct.get();
-            cart.remove(order);
-            
-            int newQuantity = order.getQuantity() - amount;
-            if (newQuantity > 0) {
-                OrderDTO updatedOrder = new OrderDTO(
-                        order.getName(),
-                        order.getCategories().stream().anyMatch(c -> c.getName().equals("Electronics")) ? 
-                            "Electronic device" : (order.getCategories().stream().anyMatch(c -> c.getName().equals("Clothing")) ?
+
+        if (existing.isPresent()) {
+            OrderDTO current = existing.get();
+            cart.remove(current);
+            int remaining = current.getQuantity() - amount;
+            if (remaining > 0) {
+                OrderDTO updated = new OrderDTO(
+                        current.getName(),
+                        current.getCategories().stream().anyMatch(c -> c.getName().equals("Electronics")) ? 
+                            "Electronic device" : (current.getCategories().stream().anyMatch(c -> c.getName().equals("Clothing")) ?
                             "Clothing item" : "Home item"),
-                        order.getCategories(),
-                        order.getStoreName(),
-                        newQuantity
+                        current.getCategories(),
+                        current.getStoreName(),
+                        remaining
                 );
-                cart.add(updatedOrder);
+                cart.add(updated);
             }
-            
-            return true;
+            return new Response<>(true);
         }
-        
-        return false;
+
+        return new Response<>(false);
     }
 
     @Override
-    public Set<OrderDTO> viewCart(String sessionToken) {
-        // If no cart exists for this session, create one with default items
+    public Response<Set<OrderDTO>> viewCart(String sessionToken) {
         ensureCartExists(sessionToken);
-        
-        return new HashSet<>(userCarts.get(sessionToken));
+        return new Response<>(new HashSet<>(userCarts.get(sessionToken)));
     }
 
     @Override
-    public boolean clearCart(String sessionToken) {
+    public Response<Boolean> clearCart(String sessionToken) {
         userCarts.put(sessionToken, new HashSet<>());
-        return true;
+        return new Response<>(true);
     }
 
     @Override
-    public boolean clearBasket(String sessionToken, String storeName) {
+    public Response<Boolean> clearBasket(String sessionToken, String storeId) {
         ensureCartExists(sessionToken);
         Set<OrderDTO> cart = userCarts.get(sessionToken);
-        
-        int initialSize = cart.size();
-        cart.removeIf(order -> order.getStoreName().equals(storeName));
-        
-        return cart.size() < initialSize;
+        boolean changed = cart.removeIf(o -> o.getStoreName().equals(storeId));
+        return new Response<>(changed);
     }
 
     @Override
-    public boolean makeBid(String sessionToken, String productName, String storeName, double bidAmount) {
-        // Simplified mock implementation
-        return bidAmount > 0;
+    public Response<Boolean> makeBid(String sessionToken, String auctionId, float bid) {
+        boolean success = bid > 0;
+        return new Response<>(success);
     }
 
     @Override
-    public boolean purchaseCart(String sessionToken, String paymentMethod, String address, String creditCardNumber, String expirationDate, String cvv) {
-        ensureCartExists(sessionToken);
-        
-        // Simple validation for mock implementation
-        boolean validPayment = paymentMethod != null && !paymentMethod.isEmpty();
-        boolean validAddress = address != null && !address.isEmpty();
-        boolean validCreditCard = creditCardNumber != null && creditCardNumber.length() >= 13;
-        boolean validExpiration = expirationDate != null && expirationDate.contains("/");
-        boolean validCvv = cvv != null && cvv.length() >= 3;
-        
-        if (validPayment && validAddress && validCreditCard && validExpiration && validCvv) {
-            // Clear the cart upon successful purchase
+    public Response<Boolean> purchaseCart(String sessionToken, String cardNumber, Date expiryDate, String cvv, long andIncrement, String clientName, String deliveryAddress) {
+        boolean valid = cardNumber != null && !cardNumber.isEmpty()
+                     && expiryDate != null
+                     && cvv != null && cvv.length() >= 3
+                     && clientName != null && !clientName.isEmpty()
+                     && deliveryAddress != null && !deliveryAddress.isEmpty();
+
+        if (valid) {
             clearCart(sessionToken);
-            return true;
+            return new Response<>(true);
         }
-        
-        return false;
+
+        return new Response<>(false);
     }
-    
-    // Helper method to ensure a cart exists for the session and populate it with default items if empty
+
     private void ensureCartExists(String sessionToken) {
-        if (!userCarts.containsKey(sessionToken)) {
-            // First check if this is a known token from LoginPresenterMock
-            if (sessionToken.equals(GUEST_TOKEN) || sessionToken.equals(REGISTERED_TOKEN) || sessionToken.equals(LOGIN_TOKEN)) {
-                // These should already be initialized in the constructor, but just in case
-                Set<OrderDTO> newCart = new HashSet<>(defaultCartItems);
-                userCarts.put(sessionToken, newCart);
-            } else {
-                // For unknown tokens, just create a cart with default items
-                Set<OrderDTO> newCart = new HashSet<>(defaultCartItems);
-                userCarts.put(sessionToken, newCart);
-            }
-        }
+        userCarts.putIfAbsent(sessionToken, new HashSet<>(defaultCartItems));
     }
-} 
+}


### PR DESCRIPTION
closes #191

## Summary by Sourcery

Overhaul the purchase presentation layer by introducing a real PurchasePresenter, revamping the IPurchasePresenter interface to use standardized identifiers and Response wrappers, and simplifying the mock presenter accordingly.

New Features:
- Add PurchasePresenter implementation that delegates cart and checkout operations to ShoppingService

Enhancements:
- Revamp IPurchasePresenter methods to use productId/storeId parameters, wrap outputs in Response<T>, and expand purchaseCart signature
- Simplify PurchasePresenterMock by unifying default cart items, removing hardcoded tokens, and adopting id-based logic with Response returns
- Align ShoppingService.makeBid parameter order to match the updated interface