### PR TITLE
217 add initialization managers

### DIFF
--- a/src/main/java/Application/ServiceManager.java
+++ b/src/main/java/Application/ServiceManager.java
@@ -1,0 +1,85 @@
+package Application;
+
+
+import Domain.FacadeManager;
+import Domain.TokenService;
+
+public class ServiceManager {
+    private ItemService itemService;
+    private StoreService storeService;
+    private ProductService productService;
+    private MarketService marketService;
+    private TokenService tokenService;
+    private UserService userService;
+    private CustomerServiceService customerService;
+    private ShoppingService shoppingService;
+    private FacadeManager facadeManager;
+
+    public ServiceManager(FacadeManager facadeManager) {
+        this.facadeManager = facadeManager;
+    }
+
+    public TokenService getTokenService() {
+        if (tokenService == null) {
+            tokenService = new TokenService();
+        }
+        return tokenService;
+    }
+
+    public ItemService getItemService() {
+        if (itemService == null) {
+            itemService = new ItemService(facadeManager.getItemFacade(),
+                                        getTokenService(),
+                                        facadeManager.getPermissionManager());
+        }
+        return itemService;
+    }
+
+    public StoreService getStoreService() {
+        if (storeService == null) {
+            storeService = new StoreService(facadeManager.getStoreFacade(),
+                                            getTokenService(),
+                                            facadeManager.getPermissionManager());
+        }
+        return storeService;
+    }
+    public ProductService getProductService() {
+        if (productService == null) {
+            productService = new ProductService(facadeManager.getProductFacade(),
+                                                getTokenService());
+        }
+        return productService;
+    }
+
+    public MarketService getMarketService() {
+        if (marketService == null) {
+            marketService = new MarketService(facadeManager.getMarketFacade(),
+                                            getTokenService());
+        }
+        return marketService;
+    }
+    public UserService getUserService() {
+        if (userService == null) {
+            userService = new UserService(facadeManager.getLoginManager(),
+                                        getTokenService());
+        }
+        return userService;
+    }
+
+    public CustomerServiceService getCustomerService() {
+        if (customerService == null) {
+            customerService = new CustomerServiceService(facadeManager.getStoreFacade(),
+                                                        getTokenService());
+        }
+        return customerService;
+    }
+
+    public ShoppingService getShoppingService() {
+        if (shoppingService == null) {
+            shoppingService = new ShoppingService(facadeManager.getShoppingCartFacade(),
+                                                getTokenService(),
+                                                facadeManager.getStoreFacade());
+        }
+        return shoppingService;
+    }
+}

--- a/src/main/java/Application/ShoppingService.java
+++ b/src/main/java/Application/ShoppingService.java
@@ -36,6 +36,12 @@ public class ShoppingService{
         this.storeFacade = storeFacade;
     }
 
+    public ShoppingService(IShoppingCartFacade cartFacade, TokenService tokenService, StoreFacade storeFacade) {
+        this.cartFacade = cartFacade;
+        this.tokenService = tokenService;
+        this.storeFacade = storeFacade;
+    }
+
     public Response<Boolean> addProductToCart(String storeId, String sessionToken, String productId, int quantity) {
         if (!tokenService.validateToken(sessionToken)) {
             return Response.error("Invalid token");

--- a/src/main/java/Domain/FacadeManager.java
+++ b/src/main/java/Domain/FacadeManager.java
@@ -1,0 +1,83 @@
+package Domain;
+
+import Domain.ExternalServices.IPaymentService;
+import Domain.Shopping.IShoppingCartFacade;
+import Domain.Shopping.ShoppingCartFacade;
+import Domain.Store.ItemFacade;
+import Domain.Store.ProductFacade;
+import Domain.Store.StoreFacade;
+import Domain.management.IMarketFacade;
+import Domain.management.MarketFacade;
+import Infrastructure.PaymentService;
+
+public class FacadeManager {
+    private IRepoManager repoManager;
+    private IMarketFacade marketFacade;
+    private IShoppingCartFacade CartFacade;
+    private StoreFacade storeFacade;
+    private ItemFacade itemFacade;
+    private ProductFacade productFacade;
+    private IPaymentService paymentService;
+
+
+    public FacadeManager(IRepoManager repoManager, String paymentServiceURL) {
+        this.repoManager = repoManager;
+        this.paymentService = new PaymentService(paymentServiceURL);
+    }
+
+    public IPaymentService getPaymentService() {
+        return paymentService;
+    }
+
+    public IMarketFacade getMarketFacade() {
+        if (marketFacade == null) {
+            marketFacade = MarketFacade.getInstance();
+            marketFacade.initFacades(repoManager.getUserRepository(),
+                                    repoManager.getItemRepository(),
+                                    getStoreFacade(),
+                                    getShoppingCartFacade());
+
+        }
+        return marketFacade;
+    }
+
+    public StoreFacade getStoreFacade() {
+        if (storeFacade == null) {
+            storeFacade = new StoreFacade(repoManager.getStoreRepository(),
+                                        repoManager.getFeedbackRepository(),
+                                        repoManager.getItemRepository(),
+                                        repoManager.getUserRepository(),
+                                        repoManager.getAuctionRepository());
+        }
+        return storeFacade;
+    }
+
+    public ItemFacade getItemFacade() {
+        if (itemFacade == null) {
+            itemFacade = new ItemFacade(repoManager.getItemRepository(),
+                                        repoManager.getProductRepository(),
+                                        repoManager.getStoreRepository());
+        }
+        return itemFacade;
+    }
+
+    public IShoppingCartFacade getShoppingCartFacade() {
+        if (CartFacade == null) {
+            CartFacade = new ShoppingCartFacade(repoManager.getShoppingCartRepository(),
+                                                repoManager.getShoppingBasketRepository(),
+                                                getPaymentService(),
+                                                getItemFacade(),
+                                                getStoreFacade(),
+                                                repoManager.getReceiptRepository(),
+                                                repoManager.getProductRepository());
+        }
+        return CartFacade;
+    }
+
+    public ProductFacade getProductFacade() {
+        if (productFacade == null) {
+            productFacade = new ProductFacade(repoManager.getProductRepository());
+        }
+        return productFacade;
+    }
+}

--- a/src/main/java/Domain/FacadeManager.java
+++ b/src/main/java/Domain/FacadeManager.java
@@ -1,14 +1,17 @@
 package Domain;
 
+
 import Domain.ExternalServices.IPaymentService;
 import Domain.Shopping.IShoppingCartFacade;
 import Domain.Shopping.ShoppingCartFacade;
 import Domain.Store.ItemFacade;
 import Domain.Store.ProductFacade;
 import Domain.Store.StoreFacade;
+import Domain.User.LoginManager;
+import Domain.User.PasswordChecker;
 import Domain.management.IMarketFacade;
 import Domain.management.MarketFacade;
-import Infrastructure.PaymentService;
+import Domain.management.PermissionManager;
 
 public class FacadeManager {
     private IRepoManager repoManager;
@@ -18,11 +21,13 @@ public class FacadeManager {
     private ItemFacade itemFacade;
     private ProductFacade productFacade;
     private IPaymentService paymentService;
+    private LoginManager loginManager;
+    private PermissionManager permissionManager;
+    private PasswordChecker passwordChecker;
 
-
-    public FacadeManager(IRepoManager repoManager, String paymentServiceURL) {
+    public FacadeManager(IRepoManager repoManager, IPaymentService paymentService) {
         this.repoManager = repoManager;
-        this.paymentService = new PaymentService(paymentServiceURL);
+        this.paymentService = paymentService;
     }
 
     public IPaymentService getPaymentService() {
@@ -79,5 +84,18 @@ public class FacadeManager {
             productFacade = new ProductFacade(repoManager.getProductRepository());
         }
         return productFacade;
+    }
+
+    public LoginManager getLoginManager() {
+        if (loginManager == null) {
+            loginManager = new LoginManager(repoManager.getUserRepository());
+        }
+        return loginManager;
+    }
+    public PermissionManager getPermissionManager() {
+        if (permissionManager == null) {
+            permissionManager = new PermissionManager(repoManager.getPermissionRepository());
+        }
+        return permissionManager;
     }
 }

--- a/src/main/java/Domain/IRepoManager.java
+++ b/src/main/java/Domain/IRepoManager.java
@@ -1,0 +1,25 @@
+package Domain;
+
+import Domain.Shopping.IReceiptRepository;
+import Domain.Shopping.IShoppingBasketRepository;
+import Domain.Shopping.IShoppingCartRepository;
+import Domain.Store.IAuctionRepository;
+import Domain.Store.IFeedbackRepository;
+import Domain.Store.IItemRepository;
+import Domain.Store.IProductRepository;
+import Domain.Store.IStoreRepository;
+import Domain.User.IUserRepository;
+import Domain.management.IPermissionRepository;
+
+public interface IRepoManager {
+    public IStoreRepository getStoreRepository();
+    public IItemRepository getItemRepository();
+    public IPermissionRepository getPermissionRepository();
+    public IReceiptRepository getReceiptRepository();
+    public IShoppingBasketRepository getShoppingBasketRepository();
+    public IShoppingCartRepository getShoppingCartRepository();
+    public IAuctionRepository getAuctionRepository();
+    public IFeedbackRepository getFeedbackRepository();
+    public IProductRepository getProductRepository();
+    public IUserRepository getUserRepository();
+}

--- a/src/main/java/Domain/Store/ProductFacade.java
+++ b/src/main/java/Domain/Store/ProductFacade.java
@@ -2,9 +2,6 @@ package Domain.Store;
 import java.util.List;
 import java.util.UUID;
 
-import Domain.Store.IProductRepository;
-import Domain.Store.IStoreRepository;
-
 public class ProductFacade {
     private IProductRepository productRepository;
 

--- a/src/main/java/Infrastructure/MemoryRepoManager.java
+++ b/src/main/java/Infrastructure/MemoryRepoManager.java
@@ -1,0 +1,108 @@
+package Infrastructure;
+
+import Domain.IRepoManager;
+import Domain.Shopping.IReceiptRepository;
+import Domain.Shopping.IShoppingBasketRepository;
+import Domain.Shopping.IShoppingCartRepository;
+import Domain.Store.IAuctionRepository;
+import Domain.Store.IFeedbackRepository;
+import Domain.Store.IItemRepository;
+import Domain.Store.IProductRepository;
+import Domain.Store.IStoreRepository;
+import Domain.User.IUserRepository;
+import Domain.management.IPermissionRepository;
+import Infrastructure.Repositories.MemoryAuctionRepository;
+import Infrastructure.Repositories.MemoryFeedbackRepository;
+import Infrastructure.Repositories.MemoryItemRepository;
+import Infrastructure.Repositories.MemoryPermissionRepository;
+import Infrastructure.Repositories.MemoryProductRepository;
+import Infrastructure.Repositories.MemoryReceiptRepository;
+import Infrastructure.Repositories.MemoryShoppingBasketRepository;
+import Infrastructure.Repositories.MemoryShoppingCartRepository;
+import Infrastructure.Repositories.MemoryStoreRepository;
+import Infrastructure.Repositories.MemoryUserRepository;
+
+public class MemoryRepoManager implements IRepoManager {
+    private MemoryItemRepository itemRepository;
+    private MemoryStoreRepository storeRepository;
+    private MemoryPermissionRepository permissionRepository;
+    private MemoryReceiptRepository receiptRepository;
+    private MemoryShoppingBasketRepository shoppingBasketRepository;
+    private MemoryShoppingCartRepository shoppingCartRepository;
+    private MemoryAuctionRepository auctionRepository;
+    private MemoryFeedbackRepository feedbackRepository;
+    private MemoryProductRepository productRepository;
+    private MemoryUserRepository userRepository;
+    
+    @Override
+    public IStoreRepository getStoreRepository() {
+        if (storeRepository == null) {
+            storeRepository = new MemoryStoreRepository();
+        }
+        return storeRepository;
+    }
+    @Override
+    public IItemRepository getItemRepository() {
+        if (itemRepository == null) {
+            itemRepository = new MemoryItemRepository();
+        }
+        return itemRepository;
+    }
+    @Override
+    public IPermissionRepository getPermissionRepository() {
+        if (permissionRepository == null) {
+            permissionRepository = new MemoryPermissionRepository();
+        }
+        return permissionRepository;
+    }
+    @Override
+    public IReceiptRepository getReceiptRepository() {
+        if (receiptRepository == null) {
+            receiptRepository = new MemoryReceiptRepository();
+        }
+        return receiptRepository;
+    }
+    @Override
+    public IShoppingBasketRepository getShoppingBasketRepository() {
+        if (shoppingBasketRepository == null) {
+            shoppingBasketRepository = new MemoryShoppingBasketRepository();
+        }
+        return shoppingBasketRepository;
+    }
+    @Override
+    public IShoppingCartRepository getShoppingCartRepository() {
+        if (shoppingCartRepository == null) {
+            shoppingCartRepository = new MemoryShoppingCartRepository();
+        }
+        return shoppingCartRepository;
+    }
+    @Override
+    public IAuctionRepository getAuctionRepository() {
+        if (auctionRepository == null) {
+            auctionRepository = new MemoryAuctionRepository();
+        }
+        return auctionRepository;
+    }
+    @Override
+    public IFeedbackRepository getFeedbackRepository() {
+        if (feedbackRepository == null) {
+            feedbackRepository = new MemoryFeedbackRepository();
+        }
+        return feedbackRepository;
+    }
+    @Override
+    public IProductRepository getProductRepository() {
+        if (productRepository == null) {
+            productRepository = new MemoryProductRepository();
+        }
+        return productRepository;
+    }
+    @Override
+    public IUserRepository getUserRepository() {
+        if (userRepository == null) {
+            userRepository = new MemoryUserRepository();
+        }
+        return userRepository;
+    }
+    
+}


### PR DESCRIPTION
close #217

## Summary by Sourcery

Introduce centralized initialization managers to streamline and lazily instantiate repositories, domain facades, and application services.

Enhancements:
- Add IRepoManager interface and MemoryRepoManager for lazy initialization of memory-based repositories
- Introduce FacadeManager for centralized, lazy wiring of domain facades and managers
- Implement ServiceManager to centralize, lazy instantiate application services with TokenService
- Provide a new constructor in ShoppingService for facade and token injection
- Clean up unused imports in ProductFacade