### PR TITLE
Fixed starting screen bug

### DIFF
--- a/src/main/java/UI/views/HomePageView.java
+++ b/src/main/java/UI/views/HomePageView.java
@@ -60,7 +60,7 @@ public class HomePageView extends VerticalLayout implements BeforeEnterObserver 
 
         Button logoutBtn = new Button("Logout", e -> {
             UI.getCurrent().getSession().close();
-            UI.getCurrent().navigate("login");
+            UI.getCurrent().navigate("");
         });
         logoutBtn.getStyle().set("background-color", "#e53e3e").set("color", "white");
 
@@ -131,7 +131,7 @@ public class HomePageView extends VerticalLayout implements BeforeEnterObserver 
         sessionToken = (String) UI.getCurrent().getSession().getAttribute("sessionToken");
         if (sessionToken == null) {
             Notification.show("Access denied. Please log in.", 4000, Notification.Position.MIDDLE);
-            event.forwardTo("login");
+            event.forwardTo("");
         }
     }
 }

--- a/src/main/java/UI/views/LoginView.java
+++ b/src/main/java/UI/views/LoginView.java
@@ -15,7 +15,7 @@ import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@Route("login")
+@Route("")
 public class LoginView extends VerticalLayout {
 
     private final ILoginPresenter loginPresenter;


### PR DESCRIPTION
Fixed the bug where the loading screen is not initialized, now the default screen is the login view. Closes #240

## Summary by Sourcery

Fix access and startup navigation by making the login view the default route and updating related navigation calls

Bug Fixes:
- Change LoginView route to the root path so the login screen loads by default
- Update logout and unauthorized redirects to use the default route instead of "login"