### PR TITLE
Added JaCoCo code coverage plugin configuration to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,53 @@
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>3.1.4</version>
       </plugin>
+
+      <!-- JaCoCo Code Coverage Plugin -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.11</version>
+        <configuration>
+          <rules>
+            <rule>
+              <element>PACKAGE</element>
+              <limits>
+                <limit>
+                  <counter>LINE</counter>
+                  <value>COVEREDRATIO</value>
+                  <minimum>0.80</minimum>
+                </limit>
+                <limit>
+                  <counter>BRANCH</counter>
+                  <value>COVEREDRATIO</value>
+                  <minimum>0.80</minimum>
+                </limit>
+              </limits>
+            </rule>
+          </rules>
+        </configuration>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## Summary by Sourcery

Configure the project’s Maven build to integrate JaCoCo for code coverage and enforce minimum coverage thresholds

Build:
- Add jacoco-maven-plugin (v0.8.11) with prepare-agent, report, and check executions
- Define package-level coverage rules requiring at least 80% line and branch coverage