### PR TITLE
282 add date to permissions for ban user

### DIFF
--- a/src/main/java/Domain/management/Permission.java
+++ b/src/main/java/Domain/management/Permission.java
@@ -1,5 +1,7 @@
 package Domain.management;
 
+import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -7,14 +9,28 @@ import java.util.Set;
 public class Permission {
 
     private final String member;
-    private final String permissionGiverName;
+    private final String permissionGiverId;
     private RoleType role;
     private Set<PermissionType> permissions;
+    private Date expirationDate;
+    private Date creationDate;
 
-    public Permission(String permissionGiverName, String member) {
-        this.permissionGiverName = permissionGiverName;
+    public Permission(String permissionGiverId, String member) {
+        this.permissionGiverId = permissionGiverId;
         this.member = member;
         this.permissions = Collections.synchronizedSet(new HashSet<>());
+        this.role = null;
+        this.creationDate = new Date();
+        this.expirationDate = new Date(Long.MAX_VALUE);
+    }
+
+    public Permission(String permissionGiverId, String member, Date expDate){
+        this.permissionGiverId = permissionGiverId;
+        this.member = member;
+        this.permissions = Collections.synchronizedSet(new HashSet<>());
+        this.role = null;
+        this.creationDate = new Date();
+        this.expirationDate = expDate;
     }
 
     public void setPermissions(Set<PermissionType> permissionTypes) {
@@ -65,11 +81,19 @@ public class Permission {
         return role == RoleType.TRADING_MANAGER;
     }
 
-    public String getPermissionGiverName() {
-        return permissionGiverName;
+    public String getPermissionGiverId() {
+        return permissionGiverId;
     }
 
     public String getMember() {
         return member;
+    }
+
+    public Date getExpirationDate() {
+        return expirationDate;
+    }
+
+    public void setExpirationDate(Date expirationDate) {
+        this.expirationDate = expirationDate;
     }
 }


### PR DESCRIPTION
closes #282

## Summary by Sourcery

Add date tracking to Permission, enable timed bans with expiration dates, and streamline ban/unban logic in PermissionManager

New Features:
- Introduce creationDate and expirationDate to permissions to support time-bound permissions
- Add overloaded getOrCreatePermission method to accept an expiration date when initializing permissions

Enhancements:
- Rename permissionGiverName field and accessors to permissionGiverId
- Refactor unbanUser to use removeAllPermissions and return updated ban status
- Automatically remove expired bans when checking isBanned