### PR TITLE
305 close store in trading view

### DIFF
--- a/src/main/frontend/ws-client.js
+++ b/src/main/frontend/ws-client.js
@@ -4,8 +4,9 @@ import { Client } from '@stomp/stompjs';
 const waitForUserId = () => {
   return new Promise((resolve) => {
     const check = () => {
-      if (window.currentUserId) {
-        resolve(window.currentUserId);
+      const userId = window.currentUserId || sessionStorage.getItem('currentUserId');
+      if (userId) {
+        resolve(userId);
       } else {
         setTimeout(check, 50);
       }
@@ -14,9 +15,49 @@ const waitForUserId = () => {
   });
 };
 
-waitForUserId().then((userId) => {
+const showNotification = (message) => {
+  // Create a Vaadin notification directly
+  const notification = document.createElement('vaadin-notification');
+  notification.position = 'top-stretch';
+  notification.duration = 10000;
+  
+  const content = document.createElement('div');
+  content.style.padding = '1em';
+  content.style.background = '#ff9800';
+  content.style.color = 'white';
+  content.style.textAlign = 'center';
+  content.style.fontSize = 'var(--lumo-font-size-m)';
+  content.textContent = message;
+  
+  notification.renderer = (root) => {
+    if (root.firstElementChild) {
+      root.removeChild(root.firstElementChild);
+    }
+    root.appendChild(content);
+  };
+  
+  document.body.appendChild(notification);
+  notification.open();
+  
+  // Remove the notification element after it's closed
+  setTimeout(() => {
+    document.body.removeChild(notification);
+  }, 10000);
+};
+
+let stompClient = null;
+
+const connectWebSocket = (userId) => {
+  if (stompClient) {
+    try {
+      stompClient.deactivate();
+    } catch (e) {
+      console.error('[WS] Error deactivating previous connection:', e);
+    }
+  }
+
   const socket = new SockJS('/ws');
-  const stompClient = new Client({
+  stompClient = new Client({
     webSocketFactory: () => socket,
     connectHeaders: {
       userId: userId
@@ -24,14 +65,35 @@ waitForUserId().then((userId) => {
     onConnect: () => {
       console.log(`[WS] Connected as ${userId}`);
       stompClient.subscribe(`/user/${userId}/topic/notifications`, (message) => {
-        alert(`🔔 ${message.body}`);
+        console.log('[WS] Received notification:', message.body);
+        showNotification(message.body);
       });
     },
     onStompError: (frame) => {
       console.error('[WS] STOMP error:', frame);
     },
+    onWebSocketClose: () => {
+      console.log('[WS] Connection closed, attempting to reconnect...');
+      setTimeout(() => connectWebSocket(userId), 5000);
+    },
     reconnectDelay: 5000
   });
 
   stompClient.activate();
+};
+
+// Listen for userId changes
+window.addEventListener('storage', (event) => {
+  if (event.key === 'currentUserId') {
+    const userId = event.newValue;
+    if (userId) {
+      connectWebSocket(userId);
+    }
+  }
+});
+
+waitForUserId().then((userId) => {
+  // Store userId in sessionStorage for cross-window access
+  sessionStorage.setItem('currentUserId', userId);
+  connectWebSocket(userId);
 });

--- a/src/main/java/Application/ServiceManager.java
+++ b/src/main/java/Application/ServiceManager.java
@@ -61,7 +61,8 @@ public class ServiceManager {
             storeService = new StoreService(facadeManager.getStoreFacade(),
                                             getTokenService(),
                                             facadeManager.getPermissionManager(),
-                                            getINotificationService());
+                                            getINotificationService(),
+                                            facadeManager.getShoppingCartFacade());
         }
         return storeService;
     }

--- a/src/main/java/Application/StoreService.java
+++ b/src/main/java/Application/StoreService.java
@@ -3,6 +3,8 @@ package Application;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.Set;
+import java.util.HashSet;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,7 @@ import Domain.Store.StoreFacade;
 import Domain.management.PermissionManager;
 import Domain.management.PermissionType;
 import Domain.management.Permission;
+import Domain.Shopping.IShoppingCartFacade;
 
 @Service
 public class StoreService {
@@ -30,21 +33,24 @@ public class StoreService {
     private TokenService tokenService;
     private PermissionManager permissionManager;
     private INotificationService notificationService;
-
+    private IShoppingCartFacade shoppingCartFacade;
 
     public StoreService() {
         this.storeFacade = null;
         this.tokenService = null;
         this.permissionManager = null;
         this.notificationService = null;
+        this.shoppingCartFacade = null;
     }
 
     @Autowired
-    public StoreService(StoreFacade storeFacade, TokenService tokenService, PermissionManager permissionManager, INotificationService notificationService) {
+    public StoreService(StoreFacade storeFacade, TokenService tokenService, PermissionManager permissionManager, 
+                       INotificationService notificationService, IShoppingCartFacade shoppingCartFacade) {
         this.notificationService = notificationService;
         this.storeFacade = storeFacade;
         this.tokenService = tokenService;
         this.permissionManager = permissionManager;
+        this.shoppingCartFacade = shoppingCartFacade;
         TradingLogger.logEvent(CLASS_NAME, "Constructor", "StoreService initialized with dependencies");
     }
 
@@ -272,6 +278,27 @@ public class StoreService {
         } catch (Exception ex) {
             TradingLogger.logError(CLASS_NAME, method, "Error accepting bid for auction %s: %s", auctionId, ex.getMessage());
             return new Response<>(new Error(ex.getMessage()));
+        }
+    }
+
+    /**
+     * Gets all users who have shopping baskets in a specific store.
+     * 
+     * @param storeId The ID of the store
+     * @return A set of user IDs who have baskets in the store
+     */
+    public Set<String> getUsersWithBaskets(String storeId) {
+        String method = "getUsersWithBaskets";
+        try {
+            if(!this.isInitialized()) {
+                TradingLogger.logError(CLASS_NAME, method, "StoreService is not initialized");
+                throw new RuntimeException("StoreService is not initialized.");
+            }
+            
+            return shoppingCartFacade.getUsersWithBaskets(storeId);
+        } catch (Exception ex) {
+            TradingLogger.logError(CLASS_NAME, method, "Error getting users with baskets for store %s: %s", storeId, ex.getMessage());
+            return new HashSet<>(); // Return empty set in case of error
         }
     }
 }

--- a/src/main/java/Domain/Shopping/IShoppingCartFacade.java
+++ b/src/main/java/Domain/Shopping/IShoppingCartFacade.java
@@ -137,4 +137,12 @@ public interface IShoppingCartFacade {
     List<Receipt> getStorePurchaseHistory(String storeId);
 
     String getStoreName(String storeId);
+
+    /**
+     * Gets all users who have shopping baskets in a specific store.
+     * 
+     * @param storeId The ID of the store
+     * @return A set of user IDs who have baskets in the store
+     */
+    Set<String> getUsersWithBaskets(String storeId);
 }

--- a/src/main/java/Domain/Shopping/IShoppingCartRepository.java
+++ b/src/main/java/Domain/Shopping/IShoppingCartRepository.java
@@ -1,6 +1,7 @@
 package Domain.Shopping;
 
 import Domain.ILockbasedRepository;
+import java.util.Map;
 
 /**
  * Abstract repository class for managing shopping carts.
@@ -13,4 +14,11 @@ public abstract class IShoppingCartRepository extends ILockbasedRepository<IShop
      * This method should clear the entire repository state.
      */
     abstract public void clear();
+
+    /**
+     * Gets all shopping carts in the repository.
+     * 
+     * @return A map of client IDs to their shopping carts
+     */
+    abstract public Map<String, IShoppingCart> getAll();
 }

--- a/src/main/java/Domain/Shopping/ShoppingCartFacade.java
+++ b/src/main/java/Domain/Shopping/ShoppingCartFacade.java
@@ -607,4 +607,30 @@ public boolean checkout(String clientId, String card_number, Date expiry_date, S
     public String getStoreName(String storeId) {
         return storeFacade.getStore(storeId).getName();
     }
+
+    /**
+     * Gets all users who have shopping baskets in a specific store.
+     * 
+     * @param storeId The ID of the store
+     * @return A set of user IDs who have baskets in the store
+     */
+    @Override
+    public Set<String> getUsersWithBaskets(String storeId) {
+        Set<String> usersWithBaskets = new HashSet<>();
+        
+        // Get all carts
+        Map<String, IShoppingCart> allCarts = cartRepo.getAll();
+        
+        // For each cart, check if it contains the store
+        for (Map.Entry<String, IShoppingCart> entry : allCarts.entrySet()) {
+            String userId = entry.getKey();
+            IShoppingCart cart = entry.getValue();
+            
+            if (cart.hasStore(storeId)) {
+                usersWithBaskets.add(userId);
+            }
+        }
+        
+        return usersWithBaskets;
+    }
 }

--- a/src/main/java/Infrastructure/Repositories/MemoryShoppingCartRepository.java
+++ b/src/main/java/Infrastructure/Repositories/MemoryShoppingCartRepository.java
@@ -83,4 +83,14 @@ public class MemoryShoppingCartRepository extends IShoppingCartRepository {
     public void clear() {
         carts.clear(); 
     }
+
+    /**
+     * Gets all shopping carts in the repository.
+     * 
+     * @return A map of client IDs to their shopping carts
+     */
+    @Override
+    public Map<String, IShoppingCart> getAll() {
+        return new ConcurrentHashMap<>(carts); // Return a copy to prevent external modification
+    }
 }

--- a/src/main/java/UI/presenters/ITradingPresenter.java
+++ b/src/main/java/UI/presenters/ITradingPresenter.java
@@ -1,0 +1,9 @@
+package UI.presenters;
+
+import Application.DTOs.StoreDTO;
+import Application.utils.Response;
+
+public interface ITradingPresenter {
+    boolean closeStore(String sessionToken, String storeId);
+    Response<StoreDTO> getStoreByName(String sessionToken, String storeName);
+} 

--- a/src/main/java/UI/presenters/IUserSessionPresenter.java
+++ b/src/main/java/UI/presenters/IUserSessionPresenter.java
@@ -4,4 +4,6 @@ public interface IUserSessionPresenter {
 
     String extractUserIdFromToken(String sessionToken);
     
+    void setSessionToken(String token);
+    String getSessionToken();
 }

--- a/src/main/java/UI/presenters/TradingPresenter.java
+++ b/src/main/java/UI/presenters/TradingPresenter.java
@@ -1,0 +1,45 @@
+package UI.presenters;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import Application.StoreService;
+import Application.utils.Response;
+import Application.DTOs.StoreDTO;
+import UI.webSocketConfigurations.WebSocketNotifier;
+
+@Component
+public class TradingPresenter implements ITradingPresenter {
+    
+    private StoreService storeService;
+    
+    private WebSocketNotifier webSocketNotifier;
+    
+    private UserSessionPresenter userSessionPresenter;
+
+    private IStorePresenter storePresenter;
+
+    @Autowired
+    public TradingPresenter(StoreService storeService, WebSocketNotifier webSocketNotifier, 
+                           UserSessionPresenter userSessionPresenter, IStorePresenter storePresenter) {
+        this.storeService = storeService;
+        this.webSocketNotifier = webSocketNotifier;
+        this.userSessionPresenter = userSessionPresenter;
+        this.storePresenter = storePresenter;
+    }
+
+    @Override
+    public boolean closeStore(String sessionToken, String storeId) {
+        try {
+            Response<Boolean> response = storeService.closeStore(sessionToken, storeId);
+            return response.getValue() != null && response.getValue();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public Response<StoreDTO> getStoreByName(String sessionToken, String storeName) {
+        return storePresenter.getStoreByName(sessionToken, storeName);
+    }
+} 

--- a/src/main/java/UI/presenters/TradingPresenter.java
+++ b/src/main/java/UI/presenters/TradingPresenter.java
@@ -7,6 +7,7 @@ import Application.StoreService;
 import Application.utils.Response;
 import Application.DTOs.StoreDTO;
 import UI.webSocketConfigurations.WebSocketNotifier;
+import java.util.Set;
 
 @Component
 public class TradingPresenter implements ITradingPresenter {
@@ -32,7 +33,20 @@ public class TradingPresenter implements ITradingPresenter {
     public boolean closeStore(String sessionToken, String storeId) {
         try {
             Response<Boolean> response = storeService.closeStore(sessionToken, storeId);
-            return response.getValue() != null && response.getValue();
+            if (response.getValue() != null && response.getValue()) {
+                // Get store name for the notification message
+                Response<StoreDTO> storeResponse = storePresenter.getStoreByName(sessionToken, storeId);
+                String storeName = storeResponse.errorOccurred() ? storeId : storeResponse.getValue().getName();
+                
+                // Get all users with baskets in this store and notify them
+                Set<String> usersWithBaskets = storeService.getUsersWithBaskets(storeId);
+                for (String userId : usersWithBaskets) {
+                    webSocketNotifier.notifyUser(userId, 
+                        String.format("Store '%s' has been closed. Your shopping basket in this store has been cleared.", storeName));
+                }
+                return true;
+            }
+            return false;
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/UI/presenters/UserSessionPresenter.java
+++ b/src/main/java/UI/presenters/UserSessionPresenter.java
@@ -7,9 +7,19 @@ import Application.TokenService;
 @Component
 public class UserSessionPresenter implements IUserSessionPresenter {
     private final TokenService tokenService;
+    private String sessionToken;
 
     public UserSessionPresenter(TokenService tokenService) {
         this.tokenService = tokenService;
+        this.sessionToken = null;
+    }
+
+    public void setSessionToken(String token) {
+        this.sessionToken = token;
+    }
+
+    public String getSessionToken() {
+        return sessionToken;
     }
 
     @Override

--- a/src/main/java/UI/views/HomePageView.java
+++ b/src/main/java/UI/views/HomePageView.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.notification.NotificationVariant;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
@@ -32,6 +33,9 @@ import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.formlayout.FormLayout;
+import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.component.page.PendingJavaScriptResult;
+import com.vaadin.flow.component.ClientCallable;
 
 import java.util.List;
 import java.util.Set;
@@ -533,5 +537,22 @@ public class HomePageView extends VerticalLayout implements BeforeEnterObserver 
             .set("background-color", "#4299e1")
             .set("color", "white");
         add(tradingButton);
+    }
+
+    @ClientCallable
+    private void showNotification(String message, String type, Integer duration, String position) {
+        Notification notification = new Notification(message);
+        notification.setDuration(duration > 0 ? duration : 4000);
+        notification.setPosition(Notification.Position.valueOf(position.toUpperCase().replace('-', '_')));
+        
+        if ("error".equals(type)) {
+            notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+        } else if ("warning".equals(type)) {
+            notification.addThemeVariants(NotificationVariant.LUMO_WARNING);
+        } else if ("success".equals(type)) {
+            notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+        }
+        
+        notification.open();
     }
 }

--- a/src/main/java/UI/views/HomePageView.java
+++ b/src/main/java/UI/views/HomePageView.java
@@ -313,6 +313,8 @@ public class HomePageView extends VerticalLayout implements BeforeEnterObserver 
         userInfo.setText("Logged in as: " + (currentUsername != null ? currentUsername : "Unknown"));
 
         loadAllProducts();
+
+        setupNavigation();
     }
 
     private void setupFilterComponents() {
@@ -523,5 +525,13 @@ public class HomePageView extends VerticalLayout implements BeforeEnterObserver 
             Notification.show("Access denied. Please log in.", 4000, Notification.Position.MIDDLE);
             event.forwardTo("");
         }
+    }
+
+    private void setupNavigation() {
+        Button tradingButton = new Button("Trading Operations", e -> UI.getCurrent().navigate("trading"));
+        tradingButton.getStyle()
+            .set("background-color", "#4299e1")
+            .set("color", "white");
+        add(tradingButton);
     }
 }

--- a/src/main/java/UI/views/StoreSearchView.java
+++ b/src/main/java/UI/views/StoreSearchView.java
@@ -26,12 +26,16 @@ import com.vaadin.flow.router.Route;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.notification.NotificationVariant;
+import com.vaadin.flow.component.dependency.JsModule;
 
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.ArrayList;
 
+@JsModule("./ws-client.js")
 @Route("store-search")
 public class StoreSearchView extends VerticalLayout implements BeforeEnterObserver {
 
@@ -107,6 +111,10 @@ public class StoreSearchView extends VerticalLayout implements BeforeEnterObserv
             Notification.show("Store not found: " + response.getErrorMessage(), 3000, Notification.Position.MIDDLE);
         } else {
             StoreDTO store = response.getValue();
+            if (!store.isOpen()) {
+                Notification.show("This store is currently closed", 3000, Notification.Position.MIDDLE);
+                return;
+            }
             showStoreLayout(store);
             Notification.show("Store found: " + store.getName());
         }
@@ -266,5 +274,22 @@ public class StoreSearchView extends VerticalLayout implements BeforeEnterObserv
                 // fetchStoreByName will be triggered by the value change listener
             }
         }
+    }
+
+    @ClientCallable
+    private void showNotification(String message, String type, Integer duration, String position) {
+        Notification notification = new Notification(message);
+        notification.setDuration(duration > 0 ? duration : 10000);
+        notification.setPosition(Notification.Position.valueOf(position.toUpperCase().replace('-', '_')));
+        
+        if ("error".equals(type)) {
+            notification.addThemeVariants(NotificationVariant.LUMO_ERROR);
+        } else if ("warning".equals(type)) {
+            notification.addThemeVariants(NotificationVariant.LUMO_WARNING);
+        } else if ("success".equals(type)) {
+            notification.addThemeVariants(NotificationVariant.LUMO_SUCCESS);
+        }
+        
+        notification.open();
     }
 }

--- a/src/main/java/UI/views/TradingView.java
+++ b/src/main/java/UI/views/TradingView.java
@@ -1,0 +1,87 @@
+package UI.views;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.component.html.H2;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import UI.presenters.ITradingPresenter;
+import Application.DTOs.StoreDTO;
+import Application.utils.Response;
+
+@Route("trading")
+public class TradingView extends VerticalLayout implements BeforeEnterObserver {
+    private final ITradingPresenter tradingPresenter;
+    private final TextField storeNameField;
+    private final Button closeStoreButton;
+    private String sessionToken;
+
+    @Autowired
+    public TradingView(ITradingPresenter tradingPresenter) {
+        this.tradingPresenter = tradingPresenter;
+        
+        H2 title = new H2("Store Trading Operations");
+        storeNameField = new TextField("Store Name");
+        storeNameField.setPlaceholder("e.g., SuperTech");
+        storeNameField.setWidth("300px");
+        storeNameField.getStyle().set("background-color", "#ffffff");
+        
+        closeStoreButton = new Button("Close Store", e -> closeStore());
+        closeStoreButton.getStyle()
+            .set("background-color", "#e53935")
+            .set("color", "white");
+
+        Button homeButton = new Button("Return to Homepage", e -> UI.getCurrent().navigate("home"));
+        homeButton.getStyle()
+            .set("background-color", "#4caf50")
+            .set("color", "white");
+
+        add(title, storeNameField, closeStoreButton, homeButton);
+        setAlignItems(Alignment.CENTER);
+        setJustifyContentMode(JustifyContentMode.CENTER);
+        
+        // Set background style
+        setSizeFull();
+        setSpacing(true);
+        setPadding(true);
+        getStyle().set("background", "linear-gradient(to right, #fce4ec, #f3e5f5)");
+    }
+
+    private void closeStore() {
+        String storeName = storeNameField.getValue();
+        if (storeName == null || storeName.trim().isEmpty()) {
+            Notification.show("Please enter a store name");
+            return;
+        }
+
+        Response<StoreDTO> response = tradingPresenter.getStoreByName(sessionToken, storeName);
+        if (response.errorOccurred()) {
+            Notification.show("Store not found: " + response.getErrorMessage(), 3000, Notification.Position.MIDDLE);
+            return;
+        }
+
+        StoreDTO store = response.getValue();
+        boolean success = tradingPresenter.closeStore(sessionToken, store.getId());
+        if (success) {
+            Notification.show("Store '" + store.getName() + "' closed successfully", 3000, Notification.Position.MIDDLE);
+            storeNameField.clear();
+        } else {
+            Notification.show("Failed to close store - you may not have permission", 3000, Notification.Position.MIDDLE);
+        }
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        sessionToken = (String) UI.getCurrent().getSession().getAttribute("sessionToken");
+        if (sessionToken == null) {
+            Notification.show("Please log in first", 3000, Notification.Position.MIDDLE);
+            event.forwardTo("");
+        }
+    }
+} 

--- a/src/main/java/UI/views/components/StoreLayout.java
+++ b/src/main/java/UI/views/components/StoreLayout.java
@@ -30,59 +30,56 @@ public class StoreLayout extends VerticalLayout {
         setPadding(true);
         setWidthFull();
 
-        
         this.add(storeDetails());
-        this.add(actionButtons());
-        this.add(itemLayout);
+        if (store.isOpen()) {
+            this.add(actionButtons());
+            this.add(itemLayout);
+        } else {
+            Span closedMessage = new Span("This store is currently closed");
+            closedMessage.getStyle()
+                .set("color", "red")
+                .set("font-weight", "bold")
+                .set("font-size", "1.2em")
+                .set("margin", "20px 0");
+            this.add(closedMessage);
+        }
+    }
+
+    private HorizontalLayout storeDetails() {
+        H2 storeName = new H2(store.getName());
+        storeName.getStyle().set("margin", "0");
+
+        Span storeDescription = new Span(store.getDescription());
+        storeDescription.getStyle()
+            .set("color", "#666")
+            .set("margin-left", "20px")
+            .set("align-self", "center");
+
+        Span storeStatus = new Span(store.isOpen() ? "Open" : "Closed");
+        storeStatus.getStyle()
+            .set("color", store.isOpen() ? "green" : "red")
+            .set("font-weight", "bold")
+            .set("margin-left", "20px")
+            .set("align-self", "center");
+
+        HorizontalLayout details = new HorizontalLayout(storeName, storeDescription, storeStatus);
+        details.setAlignItems(Alignment.CENTER);
+        return details;
     }
 
     private HorizontalLayout actionButtons() {
-        // Initialize owner dashboard button
-        Button ownerDashboardButton = new Button("Store Owner Dashboard", VaadinIcon.USER.create(), e -> onOwnerButton.accept(store));
-        ownerDashboardButton.getStyle()
-            .set("background-color", "#6b46c1")
-            .set("color", "white")
-            .set("margin-left", "10px")
-            .set("cursor", "pointer");
+        Button ownerButton = new Button("Owner Actions", e -> onOwnerButton.accept(store));
+        ownerButton.getStyle()
+            .set("background-color", "#4a9eff")
+            .set("color", "white");
 
-        // Initialize manager button
-        Button managerButton = new Button("Store Management", VaadinIcon.COGS.create(), e -> onManagerButton.accept(store));
+        Button managerButton = new Button("Manager Actions", e -> onManagerButton.accept(store));
         managerButton.getStyle()
-            .set("background-color", "#2196f3")
-            .set("color", "white")
-            .set("margin-left", "10px");
-        
-        HorizontalLayout layout = new HorizontalLayout();
-        layout.add(ownerDashboardButton, managerButton);
-        return layout;
+            .set("background-color", "#4a9eff")
+            .set("color", "white");
 
+        HorizontalLayout buttons = new HorizontalLayout(ownerButton, managerButton);
+        buttons.setSpacing(true);
+        return buttons;
     }
-
-    private VerticalLayout storeDetails() {
-        H2 name = new H2(store.getName());
-        Span description = new Span(store.getDescription());
-        description.getStyle().set("color", "gray");
-        Icon statusIcon = store.isOpen() ? VaadinIcon.CHECK_CIRCLE.create() : VaadinIcon.CLOSE_CIRCLE.create();
-        statusIcon.setColor(store.isOpen() ? "green" : "red");
-
-        Span statusText = new Span(store.isOpen() ? "Open" : "Closed");
-        statusText.getStyle().set("margin-left", "0.5em");
-        HorizontalLayout statusLayout = new HorizontalLayout(statusIcon, statusText);
-        statusLayout.setAlignItems(Alignment.CENTER);
-        
-        VerticalLayout layout = new VerticalLayout();
-
-        layout.add(name, description, statusLayout);
-
-        return layout;
-    }
-
-
-
-    
-
-
-
-
-    
 }


### PR DESCRIPTION
## Summary by Sourcery

Enable administrators to close stores via a new TradingView, propagate closures through StoreService and shopping cart facade, notify affected users via enhanced WebSocket notifications, and update various UIs to reflect store open/closed status

New Features:
- Add a Trading view and presenter to close stores and trigger user notifications
- Introduce getUsersWithBaskets in shopping cart facade and repository to identify affected users
- Enhance WebSocket client to use Vaadin notifications, store userId in sessionStorage, and auto-reconnect

Enhancements:
- Refactor StoreLayout to display store open status and conditionally show actions or a closed message
- Automatically clear and notify users’ baskets for stores that have been closed
- Add navigation button on home page to access trading operations