### PR TITLE
444 intergrating external api in auction and bid

### DIFF
--- a/src/main/java/Application/DTOs/SupplyDetailsDTO.java
+++ b/src/main/java/Application/DTOs/SupplyDetailsDTO.java
@@ -10,14 +10,12 @@ public class SupplyDetailsDTO {
     private final String city;
     private final String country;
     private final String zipCode;
-    private final String holder;
 
     public SupplyDetailsDTO(String deliveryAddress, String city, String country, String zipCode, String holder) {
         this.deliveryAddress = deliveryAddress;
         this.city = city;
         this.country = country;
         this.zipCode = zipCode;
-        this.holder = holder;
     }
 
     public SupplyDetailsDTO(SupplyDetails supplyDetails) {
@@ -25,7 +23,6 @@ public class SupplyDetailsDTO {
         this.city = supplyDetails.getCity();
         this.country = supplyDetails.getCountry();
         this.zipCode = supplyDetails.getZipCode();
-        this.holder = supplyDetails.getHolder();
     }
 
     public static SupplyDetailsDTO from(SupplyDetails supplyDetails) {
@@ -33,12 +30,11 @@ public class SupplyDetailsDTO {
     }
 
     public SupplyDetails toSupplyDetails() {
-        return new SupplyDetails(this.deliveryAddress, this.city, this.country, this.zipCode, this.holder);
+        return new SupplyDetails(this.deliveryAddress, this.city, this.country, this.zipCode);
     }
 
     public String getDeliveryAddress() { return deliveryAddress; }
     public String getCity() { return city; }
     public String getCountry() { return country; }
     public String getZipCode() { return zipCode; }
-    public String getHolder() { return holder; }
 }

--- a/src/main/java/Application/DTOs/SupplyDetailsDTO.java
+++ b/src/main/java/Application/DTOs/SupplyDetailsDTO.java
@@ -1,0 +1,44 @@
+package Application.DTOs;
+
+import java.time.LocalDate;
+
+import Domain.Shopping.PaymentDetails;
+import Domain.Shopping.SupplyDetails;
+
+public class SupplyDetailsDTO {
+    private final String deliveryAddress;
+    private final String city;
+    private final String country;
+    private final String zipCode;
+    private final String holder;
+
+    public SupplyDetailsDTO(String deliveryAddress, String city, String country, String zipCode, String holder) {
+        this.deliveryAddress = deliveryAddress;
+        this.city = city;
+        this.country = country;
+        this.zipCode = zipCode;
+        this.holder = holder;
+    }
+
+    public SupplyDetailsDTO(SupplyDetails supplyDetails) {
+        this.deliveryAddress = supplyDetails.getDeliveryAddress();
+        this.city = supplyDetails.getCity();
+        this.country = supplyDetails.getCountry();
+        this.zipCode = supplyDetails.getZipCode();
+        this.holder = supplyDetails.getHolder();
+    }
+
+    public static SupplyDetailsDTO from(SupplyDetails supplyDetails) {
+        return new SupplyDetailsDTO(supplyDetails);
+    }
+
+    public SupplyDetails toSupplyDetails() {
+        return new SupplyDetails(this.deliveryAddress, this.city, this.country, this.zipCode, this.holder);
+    }
+
+    public String getDeliveryAddress() { return deliveryAddress; }
+    public String getCity() { return city; }
+    public String getCountry() { return country; }
+    public String getZipCode() { return zipCode; }
+    public String getHolder() { return holder; }
+}

--- a/src/main/java/Application/ServiceManager.java
+++ b/src/main/java/Application/ServiceManager.java
@@ -78,7 +78,8 @@ public class ServiceManager {
                                             facadeManager.getOfferManager(),
                                             facadeManager.getLoginManager(),
                                             facadeManager.getDiscountFacade(),
-                                            facadeManager.getPaymentService());
+                                            facadeManager.getPaymentService(),
+                                            facadeManager.getSupplyService());
         }
         return storeService;
     }

--- a/src/main/java/Application/ShoppingService.java
+++ b/src/main/java/Application/ShoppingService.java
@@ -20,6 +20,7 @@ import Application.DTOs.OrderedItemDTO;
 import Application.DTOs.PaymentDetailsDTO;
 import Application.DTOs.ReceiptDTO;
 import Application.DTOs.ShoppingBasketDTO;
+import Application.DTOs.SupplyDetailsDTO;
 import Application.DTOs.UserDTO;
 import Application.utils.Error;
 import Application.utils.Response;
@@ -298,7 +299,7 @@ public class ShoppingService{
     @Transactional
     public Response<Boolean> makeBid(String auctionId, String sessionToken, float price,
                                     String cardNumber, Date expiryDate, String cvv,
-                                    long andIncrement, String clientName, String deliveryAddress) {
+                                    long andIncrement, String clientName, String deliveryAddress, String city, String country, String zipCode) {
         String method = "makeBid";
         if (!tokenService.validateToken(sessionToken)) {
             TradingLogger.logError(CLASS_NAME, method, "Invalid token");
@@ -315,7 +316,7 @@ public class ShoppingService{
 
             cartFacade.makeBid(auctionId, clientId, price,
                             cardNumber, expiryDate, cvv,
-                            andIncrement, clientName, deliveryAddress);
+                            andIncrement, clientName, deliveryAddress, city, country, zipCode);
             TradingLogger.logEvent(CLASS_NAME, method, "Bid made successfully for auction " + auctionId + " by user " + clientId + " with price " + price);
             return new Response<>(true);
         } catch (Exception ex) {
@@ -394,7 +395,7 @@ public class ShoppingService{
      * @return {@link OfferDTO}
      */
     @Transactional
-    public Response<OfferDTO> makeOffer(String sessionToken, String storeId, String productId, double newPrice, PaymentDetailsDTO paymentDetailsDTO) {
+    public Response<OfferDTO> makeOffer(String sessionToken, String storeId, String productId, double newPrice, PaymentDetailsDTO paymentDetailsDTO, SupplyDetailsDTO supplyDetailsDTO) {
         String method = "makeOffer";
         if (!tokenService.validateToken(sessionToken)) {
             TradingLogger.logError(CLASS_NAME, method, "Invalid token");
@@ -408,7 +409,7 @@ public class ShoppingService{
             ItemDTO item = ItemDTO.fromItem(itemFacade.getItem(storeId, productId)); // assure real item exists
 
             
-            Offer offer = offerManager.makeOffer(clientId, storeId, productId, newPrice, paymentDetailsDTO.toPaymentDetails());
+            Offer offer = offerManager.makeOffer(clientId, storeId, productId, newPrice, paymentDetailsDTO.toPaymentDetails(), supplyDetailsDTO.toSupplyDetails());
             OfferDTO offerDTO = convertOfferToDTO(offer);
             offerDTO.getEmployeeApprovers().stream().forEach(e -> {
                 notificationService.sendNotification(e.getId(), "🔔 You've received a new offer from " + offerDTO.getMember().getUsername() + " for a " + offerDTO.getItem().getProductName() + " in store " + storeFacade.getStoreName(storeId) + "!");

--- a/src/main/java/Application/StoreService.java
+++ b/src/main/java/Application/StoreService.java
@@ -23,6 +23,7 @@ import Application.utils.Error;
 import Application.utils.Response;
 import Application.utils.TradingLogger;
 import Domain.ExternalServices.IExternalPaymentService;
+import Domain.ExternalServices.IExternalSupplyService;
 import Domain.ExternalServices.INotificationService;
 import Domain.Shopping.IShoppingCartFacade;
 import Domain.Shopping.Offer;
@@ -57,6 +58,7 @@ public class StoreService {
     private final OfferManager offerManager;
     private final LoginManager loginManager;
     private IExternalPaymentService externalPaymentService;
+    private IExternalSupplyService externalSupplyService;
 
     public StoreService() {
         this.storeFacade = null;
@@ -68,6 +70,7 @@ public class StoreService {
         // this.discountBuilder = null;
         // this.conditionBuilder = null;
         this.externalPaymentService = null;
+        this.externalSupplyService = null;
         this.loginManager = null;
         this.offerManager = null;
         this.itemFacade = null;
@@ -78,9 +81,10 @@ public class StoreService {
                        INotificationService notificationService, IShoppingCartFacade shoppingCartFacade, ItemFacade itemFacade, 
                        OfferManager offerManager, 
                        LoginManager loginManager, DiscountFacade discountFacade,
-                       IExternalPaymentService externalPaymentService) {
+                       IExternalPaymentService externalPaymentService, IExternalSupplyService externalSupplyService) {
 
         this.externalPaymentService = externalPaymentService;
+        this.externalSupplyService = externalSupplyService;
         this.notificationService = notificationService;
         this.storeFacade = storeFacade;
         this.tokenService = tokenService;
@@ -360,7 +364,7 @@ public class StoreService {
             permissionManager.checkPermission(userId, storeId, PermissionType.OVERSEE_OFFERS);
 
             // Accept the bid for the given auction and product
-            Item item = storeFacade.acceptBid(storeId, productId, auctionId, externalPaymentService);
+            Item item = storeFacade.acceptBid(storeId, productId, auctionId, externalPaymentService, externalSupplyService);
             if (item == null) {
                 TradingLogger.logError(CLASS_NAME, method, "Failed to accept bid for auction %s", auctionId);
                 return new Response<>(new Error("Failed to accept bid. It may not exist or the auction is closed."));

--- a/src/main/java/Domain/FacadeManager.java
+++ b/src/main/java/Domain/FacadeManager.java
@@ -140,7 +140,7 @@ public class FacadeManager {
     
     public OfferManager getOfferManager() {
         if (offerManager == null) {
-            offerManager = new OfferManager(repoManager.getOfferRepository(), getPermissionManager(), repoManager.getItemRepository(), getStoreFacade(), getPaymentService(), getRepositoryManager().getReceiptRepository(), getRepositoryManager().getProductRepository());
+            offerManager = new OfferManager(repoManager.getOfferRepository(), getPermissionManager(), repoManager.getItemRepository(), getStoreFacade(), getPaymentService(), getRepositoryManager().getReceiptRepository(), getRepositoryManager().getProductRepository(), getSupplyService());
         }
         return offerManager;
     }

--- a/src/main/java/Domain/Repos/IReceiptRepository.java
+++ b/src/main/java/Domain/Repos/IReceiptRepository.java
@@ -30,7 +30,7 @@ public abstract class IReceiptRepository extends ILockbasedRepository<Receipt, S
      * @return The generated receipt ID
      */
     public abstract String savePurchase(String clientId, String storeId, Map<Product, Pair<Integer, Double>> products, 
-                       double totalPrice, String paymentDetails);
+                       double totalPrice, String paymentDetails, String supplyDetails);
     
     /**
      * Get a specific receipt by ID

--- a/src/main/java/Domain/Shopping/CheckoutManager.java
+++ b/src/main/java/Domain/Shopping/CheckoutManager.java
@@ -188,7 +188,8 @@ public class CheckoutManager {
             // Create receipts with discounted prices
             if (purchaseSuccess) {
                 String maskedCardNumber = "xxxx-xxxx-xxxx-" + cardNumber.substring(cardNumber.length() - 4);
-                receiptBuilder.createReceiptsWithDiscounts(clientId, storeProductsMap, storeProductPricesMap, maskedCardNumber);
+                String address = deliveryAddress + ", " + city + ", " + country + ", " + zipCode;
+                receiptBuilder.createReceiptsWithDiscounts(clientId, storeProductsMap, storeProductPricesMap, maskedCardNumber, address);
             }
             return new CheckoutResult(true, null, itemsRollbackData, cartRollbackData, basketsRollbackData, paymentResponse.getValue(), supplyResponse.getValue());
             

--- a/src/main/java/Domain/Shopping/IShoppingCartFacade.java
+++ b/src/main/java/Domain/Shopping/IShoppingCartFacade.java
@@ -33,7 +33,8 @@ public interface IShoppingCartFacade {
      */
     boolean makeBid(String auctionId, String clientId, float price,
                             String cardNumber, Date expiryDate, String cvv,
-                            long andIncrement, String clientName, String deliveryAddress);
+                            long andIncrement, String clientName, String deliveryAddress, String city, 
+                                        String country, String zipCode);
 
 
 

--- a/src/main/java/Domain/Shopping/Offer.java
+++ b/src/main/java/Domain/Shopping/Offer.java
@@ -20,6 +20,9 @@ public class Offer {
     @Embedded
     private PaymentDetails paymentDetails;
 
+    @Embedded
+    private SupplyDetails supplyDetails;
+
     @ElementCollection
     @CollectionTable(name = "offer_prices", joinColumns = @JoinColumn(name = "offer_id"))
     private List<PriceEntry> prices = new ArrayList<>();
@@ -31,12 +34,13 @@ public class Offer {
 
     protected Offer() {} // JPA needs a default constructor
 
-    public Offer(String memberId, String storeId, String productId, double newPrice, PaymentDetails paymentDetails) {
+    public Offer(String memberId, String storeId, String productId, double newPrice, PaymentDetails paymentDetails, SupplyDetails supplyDetails) {
         this.offerId = UUID.randomUUID().toString();
         this.memberId = memberId;
         this.storeId = storeId;
         this.productId = productId;
         this.paymentDetails = paymentDetails;
+        this.supplyDetails = supplyDetails;
         this.counterOffer = false;
         this.isAccepted = false;
 
@@ -82,4 +86,5 @@ public class Offer {
 
     public Set<String> getApprovedBy() { return approvedBy; }
     public PaymentDetails getPaymentDetails() { return paymentDetails; }
+    public SupplyDetails getSupplyDetails() { return supplyDetails; }
 }

--- a/src/main/java/Domain/Shopping/OfferManager.java
+++ b/src/main/java/Domain/Shopping/OfferManager.java
@@ -171,7 +171,7 @@ public class OfferManager {
             }
 
             SupplyDetails supplyDetails = offer.getSupplyDetails();
-            Response<Integer> supplyResponse = supplyService.supplyOrder(supplyDetails.getHolder(), supplyDetails.getDeliveryAddress(), supplyDetails.getCity(), supplyDetails.getCountry(), supplyDetails.getZipCode()); 
+            Response<Integer> supplyResponse = supplyService.supplyOrder(paymentDetails.getHolder(), supplyDetails.getDeliveryAddress(), supplyDetails.getCity(), supplyDetails.getCountry(), supplyDetails.getZipCode()); 
             if (supplyResponse.getValue() == null || supplyResponse.errorOccurred() || supplyResponse.getValue() == -1) {
                 if(paymentResponse.getValue() != -1)
                     paymentService.cancelPayment(paymentResponse.getValue());

--- a/src/main/java/Domain/Shopping/Receipt.java
+++ b/src/main/java/Domain/Shopping/Receipt.java
@@ -41,6 +41,9 @@ public class Receipt {
     
     @Column(length = 1000)
     private String paymentDetails; // Could contain masked card details or payment method
+
+    @Column(length = 1000)
+    private String supplyDetails; // Details about the supply method (e.g., delivery address)
     
     protected Receipt() {
         // Required by JPA
@@ -56,7 +59,7 @@ public class Receipt {
      * @param paymentDetails Payment method or masked card details
      */
     public Receipt(String clientId, String storeId, Map<Product, Pair<Integer, Double>> products, 
-                  double totalPrice, String paymentDetails) {
+                  double totalPrice, String paymentDetails, String supplyDetails) {
         this.receiptId = UUID.randomUUID().toString();
         this.clientId = clientId;
         this.storeId = storeId;
@@ -71,6 +74,7 @@ public class Receipt {
         this.timestamp = LocalDateTime.now();
         this.totalPrice = totalPrice;
         this.paymentDetails = paymentDetails;
+        this.supplyDetails = supplyDetails;
     }
     
     /**

--- a/src/main/java/Domain/Shopping/Receipt.java
+++ b/src/main/java/Domain/Shopping/Receipt.java
@@ -165,7 +165,8 @@ public class Receipt {
         map.put("timestamp", timestamp);
         map.put("totalPrice", totalPrice);
         map.put("paymentDetails", paymentDetails);
-        
+        map.put("supplyDetails", supplyDetails);
+
         // Convert products to map of productId to quantity and price
         Map<String, Pair<Integer, Double>> productQtyPrice = new HashMap<>();
         for (Map.Entry<String, ReceiptProduct> entry : products.entrySet()) {

--- a/src/main/java/Domain/Shopping/Receipt.java
+++ b/src/main/java/Domain/Shopping/Receipt.java
@@ -147,6 +147,10 @@ public class Receipt {
     public String getPaymentDetails() {
         return paymentDetails;
     }
+
+    public String getSupplyDetails() {
+        return supplyDetails;
+    }
     
     /**
      * Converts this receipt to a map representation for serialization or storage.

--- a/src/main/java/Domain/Shopping/ReceiptBuilder.java
+++ b/src/main/java/Domain/Shopping/ReceiptBuilder.java
@@ -34,9 +34,10 @@ public class ReceiptBuilder {
      * @param storeProductsMap Map of store IDs to their purchased products and quantities
      * @param cardNumber The card number used for payment (will be masked in receipt)
      */
-    public void createReceipts(String clientId, Map<String, Map<Product, Integer>> storeProductsMap, String cardNumber) {
+    public void createReceipts(String clientId, Map<String, Map<Product, Integer>> storeProductsMap, String cardNumber, String address) {
         String maskedCardNumber = maskCardNumber(cardNumber);
         String paymentDetails = "Card: " + maskedCardNumber;
+        String supplyDetails = "Address: " + address;
         
         for (Map.Entry<String, Map<Product, Integer>> entry : storeProductsMap.entrySet()) {
             String storeId = entry.getKey();
@@ -44,7 +45,7 @@ public class ReceiptBuilder {
             Map<Product, Double> productPrices = getProductPrices(storeId, products);
             Map<Product, Pair<Integer, Double>> productsWithPrices = mergeProductMaps(storeId, products, productPrices);
             double storeTotal = calculateStoreTotal(storeId, products);
-            receiptRepo.savePurchase(clientId, storeId, productsWithPrices, storeTotal, paymentDetails);
+            receiptRepo.savePurchase(clientId, storeId, productsWithPrices, storeTotal, paymentDetails, supplyDetails);
         }
     }
 
@@ -59,10 +60,11 @@ public class ReceiptBuilder {
     public void createReceiptsWithDiscounts(String clientId, 
                                           Map<String, Map<Product, Integer>> storeProductsMap,
                                           Map<String, Map<Product, Double>> storeProductPricesMap,
-                                          String cardNumber) {
+                                          String cardNumber, String address) {
         String maskedCardNumber = maskCardNumber(cardNumber);
         String paymentDetails = "Card: " + maskedCardNumber;
-        
+        String supplyDetails = "Address: " + address;
+
         for (Map.Entry<String, Map<Product, Integer>> entry : storeProductsMap.entrySet()) {
             String storeId = entry.getKey();
             Map<Product, Integer> products = entry.getValue();
@@ -70,7 +72,7 @@ public class ReceiptBuilder {
             Map<Product, Pair<Integer, Double>> productsWithPrices = mergeProductMaps(storeId, products, productPrices);
             
             double storeTotal = calculateStoreTotalWithDiscounts(storeId, products, productPrices);
-            receiptRepo.savePurchase(clientId, storeId, productsWithPrices, storeTotal, paymentDetails);
+            receiptRepo.savePurchase(clientId, storeId, productsWithPrices, storeTotal, paymentDetails, supplyDetails);
         }
     }
 

--- a/src/main/java/Domain/Shopping/ShoppingCartFacade.java
+++ b/src/main/java/Domain/Shopping/ShoppingCartFacade.java
@@ -235,12 +235,12 @@ public class ShoppingCartFacade implements IShoppingCartFacade {
     @Override
     public boolean makeBid(String auctionId, String clientId, float price,
                         String cardNumber, Date expiryDate, String cvv,
-                        long andIncrement, String clientName, String deliveryAddress) {
+                        long andIncrement, String clientName, String deliveryAddress, String city, String country, String zipCode) {
 
         
 
         storeFacade.addBid(auctionId, clientId, price, 
-                cardNumber, expiryDate, cvv, clientName, deliveryAddress);
+                cardNumber, expiryDate, cvv, clientName, deliveryAddress, city, country, zipCode);
         return true;
     }
 

--- a/src/main/java/Domain/Shopping/SupplyDetails.java
+++ b/src/main/java/Domain/Shopping/SupplyDetails.java
@@ -1,0 +1,31 @@
+package Domain.Shopping;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class SupplyDetails {
+
+    private String deliveryAddress;
+    private String city;
+    private String country;
+    private String zipCode;
+    private String holder;
+
+    protected SupplyDetails() {} // Required by JPA
+
+    public SupplyDetails(String deliveryAddress, String city, String country, String zipCode, String holder) {
+        this.deliveryAddress = deliveryAddress;
+        this.city = city;
+        this.country = country;
+        this.zipCode = zipCode;
+        this.holder = holder;
+    }
+
+    public String getDeliveryAddress() { return deliveryAddress; }
+    public String getCity() { return city; }
+    public String getCountry() { return country; }
+    public String getZipCode() { return zipCode; }
+    public String getHolder() { return holder; }
+}

--- a/src/main/java/Domain/Shopping/SupplyDetails.java
+++ b/src/main/java/Domain/Shopping/SupplyDetails.java
@@ -11,21 +11,18 @@ public class SupplyDetails {
     private String city;
     private String country;
     private String zipCode;
-    private String holder;
 
     protected SupplyDetails() {} // Required by JPA
 
-    public SupplyDetails(String deliveryAddress, String city, String country, String zipCode, String holder) {
+    public SupplyDetails(String deliveryAddress, String city, String country, String zipCode) {
         this.deliveryAddress = deliveryAddress;
         this.city = city;
         this.country = country;
         this.zipCode = zipCode;
-        this.holder = holder;
     }
 
     public String getDeliveryAddress() { return deliveryAddress; }
     public String getCity() { return city; }
     public String getCountry() { return country; }
     public String getZipCode() { return zipCode; }
-    public String getHolder() { return holder; }
 }

--- a/src/main/java/Domain/Store/Auction.java
+++ b/src/main/java/Domain/Store/Auction.java
@@ -28,7 +28,10 @@ public class Auction {
     @Temporal(TemporalType.DATE)
     private Date cardExpiryDate;
 
-
+    private String deliveryAddress;
+    private String city;
+    private String country;
+    private String zipCode;
 
     public Auction(String auctionId, Date auctionStartDate,
                    Date auctionEndDate, double startPrice, double currentPrice,
@@ -45,6 +48,10 @@ public class Auction {
         this.cvv = null;
         this.clientName = null;
         this.cardExpiryDate = null;
+        this.deliveryAddress = null;
+        this.city = null;
+        this.country = null;
+        this.zipCode = null;
     }
 
     protected Auction() { // changed to protected for JPA
@@ -60,6 +67,10 @@ public class Auction {
         this.cvv = null;
         this.clientName = null;
         this.cardExpiryDate = null;
+        this.deliveryAddress = null;
+        this.city = null;
+        this.country = null;
+        this.zipCode = null;
     }
 
     public String getAuctionId() {
@@ -122,14 +133,34 @@ public class Auction {
         return clientName;
     }
 
+    public String getDeliveryAddress() {
+        return deliveryAddress;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public String getZipCode() {
+        return zipCode;
+    }
+
     public void setHighestBidder(String clientId, double price,
-                          String cardNumber, Date expiryDate, String cvv, String clientName) {
+                          String cardNumber, Date expiryDate, String cvv, String clientName, String deliveryAddress, String city, String country, String zipCode) {
         this.currentBidderId = clientId;
         this.currentPrice = price;
         this.cardNumber = cardNumber;
         this.cardExpiryDate = expiryDate;
         this.cvv = cvv;
         this.clientName = clientName;
+        this.deliveryAddress = deliveryAddress;
+        this.city = city;
+        this.country = country;
+        this.zipCode = zipCode;
     }
     
     public boolean isAuctionOpen() {

--- a/src/main/java/Domain/Store/StoreFacade.java
+++ b/src/main/java/Domain/Store/StoreFacade.java
@@ -401,10 +401,10 @@ public class StoreFacade {
             // Rollback item amount
             item.setAmount(currentAmount);
             itemRepository.update(itemKey, item);
-            if(paymentSuccess.getValue() != -1) {
+            if(paymentSuccess != null && paymentSuccess.getValue() != -1) {
                 paymentService.cancelPayment(paymentSuccess.getValue());
             }
-            if(supplySuccess.getValue() != -1) {
+            if(supplySuccess != null && supplySuccess.getValue() != -1) {
                 supplyService.cancelSupply(supplySuccess.getValue());
             }
             throw new RuntimeException("Failed to charge the client for the accepted bid: " +  ex.getMessage(), ex);

--- a/src/main/java/Domain/Store/StoreFacade.java
+++ b/src/main/java/Domain/Store/StoreFacade.java
@@ -437,7 +437,7 @@ public class StoreFacade {
 
         String maskedCardNumber = "xxxx-xxxx-xxxx-" + last4;
         String paymentDetails = "Card: " + maskedCardNumber;
-        String supplyDetails = "Address: " + auction.getDeliveryAddress() + ", " + auction.getCity() + ", " + auction.getCountry() + ", " + auction.getZipCode();
+        String supplyDetails = auction.getDeliveryAddress() + ", " + auction.getCity() + ", " + auction.getCountry() + ", " + auction.getZipCode();
         try{
         this.receiptRepository.savePurchase(
             auction.getCurrentBidderId(),

--- a/src/main/java/Domain/Store/StoreFacade.java
+++ b/src/main/java/Domain/Store/StoreFacade.java
@@ -13,8 +13,10 @@ import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import Application.utils.Response;
 import Application.utils.TradingLogger;
 import Domain.ExternalServices.IExternalPaymentService;
+import Domain.ExternalServices.IExternalSupplyService;
 import Domain.ExternalServices.INotificationService;
 import Domain.Pair;
 import Domain.Repos.IAuctionRepository;
@@ -260,7 +262,7 @@ public class StoreFacade {
     }
 
     public Auction addBid(String auctionId, String userId, float bid, String cardNumber, Date expiryDate, String cvv
-                            , String clientName, String deliveryAddress) {
+                            , String clientName, String deliveryAddress, String city, String country, String zipCode) {
         TradingLogger.logEvent("StoreFacade", "addBid",
             "DEBUG: Received bid request. auctionId=" + auctionId + ", userId=" + userId + ", bid=" + bid);
 
@@ -290,7 +292,7 @@ public class StoreFacade {
                 "DEBUG: No previous bidder to notify for auction " + auctionId + " or it's the same user bidding again.");
         }
 
-        auction.setHighestBidder(userId, bid, cardNumber, expiryDate, cvv, clientName);
+        auction.setHighestBidder(userId, bid, cardNumber, expiryDate, cvv, clientName, deliveryAddress, city, country, zipCode);
 
         TradingLogger.logEvent("StoreFacade", "addBid",
             "DEBUG: Updated auction with new bid. New currentBidderId=" + userId + ", newPrice=" + bid);
@@ -318,13 +320,17 @@ public class StoreFacade {
         return this.auctionRepository.getAllProductAuctions(productId);
     }
 
-    public Item acceptBid(String storeId, String productId, String auctionId, IExternalPaymentService paymentService) {
+    public Item acceptBid(String storeId, String productId, String auctionId, IExternalPaymentService paymentService, IExternalSupplyService supplyService) {
         if (!isInitialized()) {
             throw new RuntimeException("StoreFacade is not initialized");
         }
 
         if(paymentService == null) {
             throw new RuntimeException("Payment service is not set");
+        }
+
+        if (supplyService == null) {
+            throw new IllegalArgumentException("Supply service is not set");
         }
 
         // Retrieve the item first and attempt to reserve one unit
@@ -369,23 +375,37 @@ public class StoreFacade {
         }
 
         // Charge the user using stored callback
-        Integer success = -1;
+        Response<Integer> paymentSuccess = new Response<>(-1);
+        Response<Integer> supplySuccess = new Response<>(-1);
         try {
-            success = paymentService.processPayment(auction.getCurrentBidderId(), auction.getCardNumber(), auction.getCardExpiryDate(), auction.getCvv(), auction.getClientName(), auction.getCurrentPrice()).getValue();
-            if (success == -1) {
+            paymentSuccess = paymentService.processPayment(auction.getCurrentBidderId(), auction.getCardNumber(), auction.getCardExpiryDate(), auction.getCvv(), auction.getClientName(), auction.getCurrentPrice());
+            if (paymentSuccess == null || paymentSuccess.errorOccurred() || paymentSuccess.getValue() == -1) {
                 // Rollback item amount
                 item.setAmount(currentAmount);
                 itemRepository.update(itemKey, item);
                 throw new RuntimeException("Payment failed for accepted bid");
             }
 
-            
+            supplySuccess = supplyService.supplyOrder(auction.getClientName(), auction.getDeliveryAddress(), auction.getCity(), auction.getCountry(), auction.getZipCode());
+            if (supplySuccess == null || supplySuccess.errorOccurred() || supplySuccess.getValue() == -1) {
+                if(paymentSuccess.getValue() != -1) {
+                    paymentService.cancelPayment(paymentSuccess.getValue());
+                }
+                // Rollback item amount
+                item.setAmount(currentAmount);
+                itemRepository.update(itemKey, item);
+                throw new RuntimeException("Supply processing failed for accepted bid");
+            }
+
         } catch (Exception ex) {
             // Rollback item amount
             item.setAmount(currentAmount);
             itemRepository.update(itemKey, item);
-            if(success != -1) {
-                paymentService.cancelPayment(success);
+            if(paymentSuccess.getValue() != -1) {
+                paymentService.cancelPayment(paymentSuccess.getValue());
+            }
+            if(supplySuccess.getValue() != -1) {
+                supplyService.cancelSupply(supplySuccess.getValue());
             }
             throw new RuntimeException("Failed to charge the client for the accepted bid: " +  ex.getMessage(), ex);
         }
@@ -417,13 +437,15 @@ public class StoreFacade {
 
         String maskedCardNumber = "xxxx-xxxx-xxxx-" + last4;
         String paymentDetails = "Card: " + maskedCardNumber;
+        String supplyDetails = "Address: " + auction.getDeliveryAddress() + ", " + auction.getCity() + ", " + auction.getCountry() + ", " + auction.getZipCode();
         try{
         this.receiptRepository.savePurchase(
             auction.getCurrentBidderId(),
             storeId,
             Map.of(product, new Pair<>(1, auction.getCurrentPrice())),
             auction.getCurrentPrice(),
-            paymentDetails  
+            paymentDetails,
+            supplyDetails  
         );
         } catch (Exception e) {
             // Rollback item amount

--- a/src/main/java/Infrastructure/JpaSpringRepositories/JpaReceiptRepository.java
+++ b/src/main/java/Infrastructure/JpaSpringRepositories/JpaReceiptRepository.java
@@ -29,8 +29,8 @@ public class JpaReceiptRepository extends IReceiptRepository {
 
     @Override
     public String savePurchase(String clientId, String storeId, Map<Product, Pair<Integer, Double>> products,
-            double totalPrice, String paymentDetails) {
-        Receipt receipt = new Receipt(clientId, storeId, products, totalPrice, paymentDetails);
+            double totalPrice, String paymentDetails, String supplyDetails) {
+        Receipt receipt = new Receipt(clientId, storeId, products, totalPrice, paymentDetails, supplyDetails);
         return saveReceipt(receipt);
     }
 

--- a/src/main/java/Infrastructure/MemoryRepositories/MemoryReceiptRepository.java
+++ b/src/main/java/Infrastructure/MemoryRepositories/MemoryReceiptRepository.java
@@ -67,8 +67,8 @@ public class MemoryReceiptRepository extends IReceiptRepository {
      */
     @Override
     public String savePurchase(String clientId, String storeId, Map<Product, Pair<Integer, Double>> products, 
-                       double totalPrice, String paymentDetails) {
-        Receipt receipt = new Receipt(clientId, storeId, products, totalPrice, paymentDetails);
+                       double totalPrice, String paymentDetails, String supplyDetails) {
+        Receipt receipt = new Receipt(clientId, storeId, products, totalPrice, paymentDetails, supplyDetails);
         return saveReceipt(receipt);
     }
     

--- a/src/main/java/UI/AppInitializer.java
+++ b/src/main/java/UI/AppInitializer.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import Application.DTOs.PaymentDetailsDTO;
+import Application.DTOs.SupplyDetailsDTO;
 import Application.DTOs.UserDTO;
 import Application.ItemService;
 import Application.MarketService;
@@ -241,7 +242,10 @@ public class AppInitializer implements CommandLineRunner, Ordered {
                             (String) cmd.get("cvv"),
                             ((Number) cmd.get("andIncrement")).longValue(),
                             (String) cmd.get("clientName"),
-                            (String) cmd.get("deliveryAddress"));
+                            (String) cmd.get("deliveryAddress"),
+                            (String) cmd.get("city"),
+                            (String) cmd.get("country"),
+                            (String) cmd.get("zip"));
                     if (resp.errorOccurred()) throw new RuntimeException("❌ Command '" + action + "' failed: " + resp.getErrorMessage());;
                 }
                 case "checkout" -> {
@@ -288,6 +292,12 @@ public class AppInitializer implements CommandLineRunner, Ordered {
                                 ((Number) cmd.get("expiryDate/day")).intValue()
                             ),
                             (String) cmd.get("cvv"),
+                            (String) cmd.get("holder")),
+                    new SupplyDetailsDTO(
+                            (String) cmd.get("deliveryAddress"),
+                            (String) cmd.get("city"),
+                            (String) cmd.get("country"),
+                            (String) cmd.get("zip"),
                             (String) cmd.get("holder"))
                     );
                     if (!resp.errorOccurred())

--- a/src/main/java/UI/presenters/IPurchasePresenter.java
+++ b/src/main/java/UI/presenters/IPurchasePresenter.java
@@ -9,6 +9,7 @@ import Application.DTOs.OfferDTO;
 import Application.DTOs.PaymentDetailsDTO;
 import Application.DTOs.PolicyDTO;
 import Application.DTOs.ReceiptDTO;
+import Application.DTOs.SupplyDetailsDTO;
 import Application.utils.Response;
 
 /**
@@ -89,7 +90,7 @@ public interface IPurchasePresenter {
      */
     Response<Boolean> makeBid(String auctionId, String sessionToken, float price,
                                     String cardNumber, Date expiryDate, String cvv,
-                                    long andIncrement, String clientName, String deliveryAddress);
+                                    long andIncrement, String clientName, String deliveryAddress, String city, String country, String zipCode);
 
 
     /**
@@ -134,7 +135,7 @@ public interface IPurchasePresenter {
      * @param paymentDetails payment details of the user
      * @return {@link OfferDTO}
      */
-    public Response<OfferDTO> makeOffer(String sessionToken, String storeId, String productId, double newPrice, PaymentDetailsDTO paymentDetails);
+    public Response<OfferDTO> makeOffer(String sessionToken, String storeId, String productId, double newPrice, PaymentDetailsDTO paymentDetails, SupplyDetailsDTO supplyDetails);
 
     /**
      * Retrieves all offers of a user

--- a/src/main/java/UI/presenters/PurchasePresenter.java
+++ b/src/main/java/UI/presenters/PurchasePresenter.java
@@ -12,6 +12,7 @@ import Application.DTOs.OfferDTO;
 import Application.DTOs.PaymentDetailsDTO;
 import Application.DTOs.PolicyDTO;
 import Application.DTOs.ReceiptDTO;
+import Application.DTOs.SupplyDetailsDTO;
 import Application.utils.Response;
 
 @Component
@@ -57,9 +58,9 @@ public class PurchasePresenter implements IPurchasePresenter {
     @Override
     public Response<Boolean> makeBid(String auctionId, String sessionToken, float price,
                                     String cardNumber, Date expiryDate, String cvv,
-                                    long andIncrement, String clientName, String deliveryAddress) {
+                                    long andIncrement, String clientName, String deliveryAddress, String city, String country, String zipCode) {
         return this.shoppingService.makeBid(auctionId, sessionToken, price,
-                cardNumber, expiryDate, cvv, andIncrement, clientName, deliveryAddress);
+                cardNumber, expiryDate, cvv, andIncrement, clientName, deliveryAddress, city, country, zipCode);
     }
 
     @Override
@@ -80,8 +81,8 @@ public class PurchasePresenter implements IPurchasePresenter {
     }
 
     @Override
-    public Response<OfferDTO> makeOffer(String sessionToken, String storeId, String productId, double newPrice, PaymentDetailsDTO paymentDetails) {
-        return this.shoppingService.makeOffer(sessionToken, storeId, productId, newPrice, paymentDetails);
+    public Response<OfferDTO> makeOffer(String sessionToken, String storeId, String productId, double newPrice, PaymentDetailsDTO paymentDetails, SupplyDetailsDTO supplyDetails) {
+        return this.shoppingService.makeOffer(sessionToken, storeId, productId, newPrice, paymentDetails, supplyDetails);
     }
 
     @Override

--- a/src/main/java/UI/views/HomePageView.java
+++ b/src/main/java/UI/views/HomePageView.java
@@ -236,19 +236,27 @@ public class HomePageView extends BaseView implements BeforeEnterObserver {
                     TextField name = new TextField("Full Name");
                     TextField address = new TextField("Delivery Address");
                     
+                    TextField city = new TextField("City");
+                    TextField country = new TextField("Country");
+                    TextField zipCode = new TextField("ZIP Code");
+
                     bidForm.add(
                         bidAmount,
                         cardNumber,
                         expiryDate,
                         cvv,
                         name,
-                        address
+                        address,
+                        city,
+                        country,
+                        zipCode 
                     );
                     
                     Button placeBidButton = new Button("Place Bid", event -> {
-                        if (bidAmount.getValue() == null || cardNumber.isEmpty() || 
-                            expiryDate.isEmpty() || cvv.isEmpty() || 
-                            name.isEmpty() || address.isEmpty()) {
+                        if (bidAmount.getValue() == null || cardNumber.isEmpty() ||
+                            expiryDate.isEmpty() || cvv.isEmpty() ||
+                            name.isEmpty() || address.isEmpty() ||
+                            city.isEmpty() || country.isEmpty() || zipCode.isEmpty()) {
                             Notification.show("Please fill in all fields");
                             return;
                         }
@@ -270,7 +278,10 @@ public class HomePageView extends BaseView implements BeforeEnterObserver {
                             cvv.getValue(),
                             increment,
                             name.getValue(),
-                            address.getValue()
+                            address.getValue(),
+                            city.getValue(),
+                            country.getValue(),
+                            zipCode.getValue()
                         );
                         
                         if (!response.errorOccurred() && response.getValue()) {

--- a/src/main/java/UI/views/StoreSearchView.java
+++ b/src/main/java/UI/views/StoreSearchView.java
@@ -153,8 +153,8 @@ public class StoreSearchView extends BaseView implements BeforeEnterObserver {
             },
             i -> UI.getCurrent().navigate("product-review/" + i.getProductId()),
             i -> {
-                MakeOfferDialog offerDialog = new MakeOfferDialog(i, (price, details) -> {
-                    Response<OfferDTO> offerResponse = purchasePresenter.makeOffer(sessionToken, i.getStoreId(), i.getProductId(), price, details);
+                MakeOfferDialog offerDialog = new MakeOfferDialog(i, (price, paymentDetails, supplyDetails) -> {
+                    Response<OfferDTO> offerResponse = purchasePresenter.makeOffer(sessionToken, i.getStoreId(), i.getProductId(), price, paymentDetails, supplyDetails);
                     if (offerResponse.errorOccurred()) {
                         Notification.show("Failed to make offer: " + offerResponse.getErrorMessage(), 5000, Notification.Position.BOTTOM_END);
                     } else {

--- a/src/main/java/UI/views/components/MakeOfferDialog.java
+++ b/src/main/java/UI/views/components/MakeOfferDialog.java
@@ -2,6 +2,8 @@ package UI.views.components;
 
 import Application.DTOs.ItemDTO;
 import Application.DTOs.PaymentDetailsDTO;
+import Application.DTOs.SupplyDetailsDTO;
+
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.datepicker.DatePicker;
@@ -15,11 +17,11 @@ import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.PasswordField;
 import com.vaadin.flow.component.textfield.TextField;
 
-import java.util.function.BiConsumer;
+import org.apache.commons.lang3.function.TriConsumer;
 
 public class MakeOfferDialog extends Dialog {
 
-    public MakeOfferDialog(ItemDTO item, BiConsumer<Double, PaymentDetailsDTO> onMakeOffer) {
+    public MakeOfferDialog(ItemDTO item, TriConsumer<Double, PaymentDetailsDTO, SupplyDetailsDTO> onMakeOffer) {
         setCloseOnOutsideClick(true);
         setCloseOnEsc(true);
 
@@ -56,6 +58,11 @@ public class MakeOfferDialog extends Dialog {
         TextField holderID = new TextField("Cardholder ID");
         holderID.setPlaceholder("ID number");
 
+        TextField address = new TextField("Delivery Address");
+        TextField city = new TextField("City");
+        TextField country = new TextField("Country");
+        TextField zipCode = new TextField("ZIP Code");
+
         // Payment form layout
         FormLayout form = new FormLayout();
         form.setResponsiveSteps(
@@ -66,6 +73,8 @@ public class MakeOfferDialog extends Dialog {
         form.add(offerField, cardNumber);
         form.add(expiryDate, cvv);
         form.add(holderName, holderID);
+        form.add(address, city);
+        form.add(country, zipCode);
 
         // Submit button
         Button submit = new Button("Submit Offer", e -> {
@@ -74,8 +83,10 @@ public class MakeOfferDialog extends Dialog {
                 Notification.show("Enter a valid offer price.", 4000, Notification.Position.MIDDLE);
                 return;
             }
-            if (cardNumber.isEmpty() || expiryDate.isEmpty() || cvv.isEmpty() || holderName.isEmpty() || holderID.isEmpty()) {
-                Notification.show("Please complete all payment details.", 4000, Notification.Position.MIDDLE);
+            if (cardNumber.isEmpty() || expiryDate.isEmpty() || cvv.isEmpty() || 
+                holderName.isEmpty() || holderID.isEmpty() ||
+                address.isEmpty() || city.isEmpty() || country.isEmpty() || zipCode.isEmpty()) {
+                Notification.show("Please complete all payment and delivery details.", 4000, Notification.Position.MIDDLE);
                 return;
             }
 
@@ -87,7 +98,15 @@ public class MakeOfferDialog extends Dialog {
                 holderName.getValue()
             );
 
-            onMakeOffer.accept(offer, payment);
+            SupplyDetailsDTO supply = new SupplyDetailsDTO(
+                address.getValue(),
+                city.getValue(),
+                country.getValue(),
+                zipCode.getValue(),
+                holderName.getValue()
+            );
+
+            onMakeOffer.accept(offer, payment, supply);
             close();
         });
         submit.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_SUCCESS);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Activate desired profile
-spring.profiles.active=dev
+spring.profiles.active=prod
 
 # Clean the data before running
 app.clean-on-start=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Activate desired profile
-spring.profiles.active=prod
+spring.profiles.active=dev
 
 # Clean the data before running
 app.clean-on-start=true

--- a/src/test/java/Domain/Shopping/ReceiptTest.java
+++ b/src/test/java/Domain/Shopping/ReceiptTest.java
@@ -24,7 +24,8 @@ public class ReceiptTest {
     private static final String STORE_ID = "store123";
     private static final double TOTAL_PRICE = 35.0;
     private static final String PAYMENT_DETAILS = "xxxx-xxxx-xxxx-1234";
-    
+    private static final String SUPPLY_DETAILS = "123 Main St, City, Country, 12345";
+
     @Before
     public void setUp() {
         products = new HashMap<>();
@@ -34,7 +35,7 @@ public class ReceiptTest {
         products.put(product1, new Pair<>(2, 10.0));
         products.put(product2, new Pair<>(1, 15.0));
         
-        receipt = new Receipt(CLIENT_ID, STORE_ID, products, TOTAL_PRICE, PAYMENT_DETAILS);
+        receipt = new Receipt(CLIENT_ID, STORE_ID, products, TOTAL_PRICE, PAYMENT_DETAILS, SUPPLY_DETAILS);
     }
     
     /**
@@ -53,6 +54,7 @@ public class ReceiptTest {
         assertEquals(STORE_ID, receipt.getStoreId());
         assertEquals(TOTAL_PRICE, receipt.getTotalPrice(), 0.001);
         assertEquals(PAYMENT_DETAILS, receipt.getPaymentDetails());
+        assertEquals(SUPPLY_DETAILS, receipt.getSupplyDetails());
         
         // Check that products map is not the same instance but contains the same products
         assertNotSame(products, receipt.getProducts());
@@ -125,6 +127,7 @@ public class ReceiptTest {
         assertEquals(receipt.getTimestamp(), map.get("timestamp"));
         assertEquals(TOTAL_PRICE, map.get("totalPrice"));
         assertEquals(PAYMENT_DETAILS, map.get("paymentDetails"));
+        assertEquals(SUPPLY_DETAILS, map.get("supplyDetails"));
         
         Map<String, Pair<Integer, Double>> productQuantities = (Map<String, Pair<Integer, Double>>) map.get("products");
         assertNotNull(productQuantities);

--- a/src/test/java/Domain/Shopping/ShoppingCartFacadeTest.java
+++ b/src/test/java/Domain/Shopping/ShoppingCartFacadeTest.java
@@ -301,7 +301,7 @@ public class ShoppingCartFacadeTest {
         verify(mockBasketRepo, never()).get(any(Pair.class));   
         verify(mockBasketRepo, never()).update(any(Pair.class), any(ShoppingBasket.class));
         verify(mockReceiptRepo, never()).savePurchase(
-            anyString(), anyString(), anyMap(), anyDouble(), anyString()
+            anyString(), anyString(), anyMap(), anyDouble(), anyString(), anyString()
         );
     }
     
@@ -516,16 +516,16 @@ public class ShoppingCartFacadeTest {
     public void testMakeBid_Success() {
         // Arrange
         Auction mockAuction = mock(Auction.class);
-        when(mockStoreFacade.addBid(eq(AUCTION_ID), eq(CLIENT_ID), eq(BID_PRICE), anyString(), any(), anyString(), anyString(), anyString()))
+        when(mockStoreFacade.addBid(eq(AUCTION_ID), eq(CLIENT_ID), eq(BID_PRICE), anyString(), any(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString()))
             .thenReturn(mockAuction);
 
         // Act
         boolean result = facade.makeBid(AUCTION_ID, CLIENT_ID, BID_PRICE,
-            "1234567890123456", new Date(), "123", 12345L, "John Doe", "123 Main St");
+            "1234567890123456", new Date(), "123", 12345L, "John Doe", "123 Main St", "City", "Country", "12345");
 
         // Assert
         assertTrue("Should return true for successful bid", result);
-        verify(mockStoreFacade).addBid(eq(AUCTION_ID), eq(CLIENT_ID), eq(BID_PRICE), anyString(), any(), anyString(), anyString(), anyString());
+        verify(mockStoreFacade).addBid(eq(AUCTION_ID), eq(CLIENT_ID), eq(BID_PRICE), anyString(), any(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
     }
     
     //

--- a/src/test/java/Infrastructure/ExternalServiceTest.java
+++ b/src/test/java/Infrastructure/ExternalServiceTest.java
@@ -63,6 +63,8 @@ public class ExternalServiceTest {
 
         when(mockPaymentService.processPayment(any(), any(), any(), any(), any(), anyDouble()))
             .thenReturn(Response.success(1));
+        when(mockSupplyService.supplyOrder(any(), any(), any(), any(), any()))
+            .thenReturn(Response.success(1));
         when(mockNotificationService.sendNotification(any(), any()))
             .thenReturn(Response.success(true));
 

--- a/src/test/java/Infrastructure/ExternalServiceTest.java
+++ b/src/test/java/Infrastructure/ExternalServiceTest.java
@@ -110,7 +110,7 @@ public class ExternalServiceTest {
         AuctionDTO auctionDTO = storeService.addAuction(userToken, storeId, productId, dateStr, 5.0).getValue();
         String auctionId = auctionDTO.getAuctionId();
 
-        shoppingService.makeBid(auctionId, userToken, 6.0f, "1234567812345678", new Date(), "123", 1L, "Buyer", "Address");
+        shoppingService.makeBid(auctionId, userToken, 6.0f, "1234567812345678", new Date(), "123", 1L, "Buyer", "Address", "City", "Country", "12345");
         storeService.acceptBid(userToken, storeId, productId, auctionId);
 
         verify(mockPaymentService, times(1))
@@ -130,7 +130,7 @@ public class ExternalServiceTest {
         AuctionDTO auctionDTO = storeService.addAuction(userToken, storeId, productId, dateStr, 5.0).getValue();
         String auctionId = auctionDTO.getAuctionId();
 
-        shoppingService.makeBid(auctionId, userToken, 6.0f, "1234567812345678", new Date(), "123", 1L, "Buyer", "Address");
+        shoppingService.makeBid(auctionId, userToken, 6.0f, "1234567812345678", new Date(), "123", 1L, "Buyer", "Address", "City", "Country", "12345");
         storeService.acceptBid(userToken, storeId, productId, auctionId);
 
         verify(mockNotificationService, atLeastOnce())
@@ -159,14 +159,14 @@ public class ExternalServiceTest {
         String auctionId = auctionDTO.getAuctionId();
 
         // First bid – no outbid notification expected
-        shoppingService.makeBid(auctionId, userToken, 6.0f, "1234567812345678", new Date(), "123", 1L, "FirstBuyer", "Address");
+        shoppingService.makeBid(auctionId, userToken, 6.0f, "1234567812345678", new Date(), "123", 1L, "FirstBuyer", "Address", "City", "Country", "12345");
 
         // Create a second user and bid higher
         UserDTO guest2 = userService.guestEntry().getValue();
         UserDTO user2 = userService.register(guest2.getSessionToken(), "User2", "Password2!", "user2@example.com").getValue();
         String user2Token = user2.getSessionToken();
 
-        shoppingService.makeBid(auctionId, user2Token, 7.0f, "8765432187654321", new Date(), "321", 1L, "SecondBuyer", "AnotherAddress");
+        shoppingService.makeBid(auctionId, user2Token, 7.0f, "8765432187654321", new Date(), "321", 1L, "SecondBuyer", "AnotherAddress", "AnotherCity", "AnotherCountry", "54321");
 
         verify(mockNotificationService, atLeastOnce())
             .sendNotification(anyString(), contains("outbid"));

--- a/src/test/java/Infrastructure/Repositories/MemoryReceiptRepositoryTest.java
+++ b/src/test/java/Infrastructure/Repositories/MemoryReceiptRepositoryTest.java
@@ -24,6 +24,7 @@ public class MemoryReceiptRepositoryTest {
     private static final String CLIENT_ID = "client123";
     private static final String STORE_ID = "store123";
     private static final String PAYMENT_DETAILS = "xxxx-xxxx-xxxx-1234";
+    private static final String SUPPLY_DETAILS = "123 Main St, City, Country, 12345";
     
     @Before
     public void setUp() {
@@ -37,7 +38,7 @@ public class MemoryReceiptRepositoryTest {
         products.put(createProduct("product1", "Product 1"), new Pair<>(2, 10.0));
         products.put(createProduct("product2", "Product 2"), new Pair<>(1, 15.0));
         
-        Receipt receipt = new Receipt(CLIENT_ID, STORE_ID, products, 35.0, PAYMENT_DETAILS);
+        Receipt receipt = new Receipt(CLIENT_ID, STORE_ID, products, 35.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
         
         // Save the receipt
         String receiptId = repository.saveReceipt(receipt);
@@ -61,7 +62,7 @@ public class MemoryReceiptRepositoryTest {
         products.put(createProduct("product2", "Product 2"), new Pair<>(1, 15.0));
         
         // Save the purchase
-        String receiptId = repository.savePurchase(CLIENT_ID, STORE_ID, products, 35.0, PAYMENT_DETAILS);
+        String receiptId = repository.savePurchase(CLIENT_ID, STORE_ID, products, 35.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
         
         // Verify the purchase was saved
         assertNotNull(receiptId);
@@ -71,6 +72,7 @@ public class MemoryReceiptRepositoryTest {
         assertEquals(STORE_ID, savedReceipt.getStoreId());
         assertEquals(35.0, savedReceipt.getTotalPrice(), 0.001);
         assertEquals(PAYMENT_DETAILS, savedReceipt.getPaymentDetails());
+        assertEquals(SUPPLY_DETAILS, savedReceipt.getSupplyDetails());
         assertEquals(2, savedReceipt.getProducts().size());
     }
     
@@ -80,7 +82,7 @@ public class MemoryReceiptRepositoryTest {
         Map<Product, Pair<Integer, Double>> products = new HashMap<>();
         products.put(createProduct("product1", "Product 1"), new Pair<>(2, 10.0));
         
-        Receipt receipt = new Receipt(CLIENT_ID, STORE_ID, products, 20.0, PAYMENT_DETAILS);
+        Receipt receipt = new Receipt(CLIENT_ID, STORE_ID, products, 20.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
         String receiptId = repository.saveReceipt(receipt);
         
         // Get the receipt
@@ -108,9 +110,9 @@ public class MemoryReceiptRepositoryTest {
         Map<Product, Pair<Integer, Double>> products2 = new HashMap<>();
         products2.put(createProduct("product2", "Product 2"), new Pair<>(1, 15.0));
         
-        repository.savePurchase(CLIENT_ID, STORE_ID, products1, 20.0, PAYMENT_DETAILS);
-        repository.savePurchase(CLIENT_ID, "store456", products2, 15.0, PAYMENT_DETAILS);
-        repository.savePurchase("client456", STORE_ID, products1, 20.0, PAYMENT_DETAILS);
+        repository.savePurchase(CLIENT_ID, STORE_ID, products1, 20.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
+        repository.savePurchase(CLIENT_ID, "store456", products2, 15.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
+        repository.savePurchase("client456", STORE_ID, products1, 20.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
         
         // Get the client's receipts
         List<Receipt> clientReceipts = repository.getClientReceipts(CLIENT_ID);
@@ -131,9 +133,9 @@ public class MemoryReceiptRepositoryTest {
         Map<Product, Pair<Integer, Double>> products2 = new HashMap<>();
         products2.put(createProduct("product2", "Product 2"), new Pair<>(1, 15.0));
         
-        repository.savePurchase(CLIENT_ID, STORE_ID, products1, 20.0, PAYMENT_DETAILS);
-        repository.savePurchase("client456", STORE_ID, products2, 15.0, PAYMENT_DETAILS);
-        repository.savePurchase(CLIENT_ID, "store456", products1, 20.0, PAYMENT_DETAILS);
+        repository.savePurchase(CLIENT_ID, STORE_ID, products1, 20.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
+        repository.savePurchase("client456", STORE_ID, products2, 15.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
+        repository.savePurchase(CLIENT_ID, "store456", products1, 20.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
         
         // Get the store's receipts
         List<Receipt> storeReceipts = repository.getStoreReceipts(STORE_ID);
@@ -154,11 +156,11 @@ public class MemoryReceiptRepositoryTest {
         Map<Product, Pair<Integer, Double>> products2 = new HashMap<>();
         products2.put(createProduct("product2", "Product 2"), new Pair<>(1, 15.0));
         
-        repository.savePurchase(CLIENT_ID, STORE_ID, products1, 20.0, PAYMENT_DETAILS);
-        repository.savePurchase(CLIENT_ID, STORE_ID, products2, 15.0, PAYMENT_DETAILS);
-        repository.savePurchase(CLIENT_ID, "store456", products1, 20.0, PAYMENT_DETAILS);
-        repository.savePurchase("client456", STORE_ID, products1, 20.0, PAYMENT_DETAILS);
-        
+        repository.savePurchase(CLIENT_ID, STORE_ID, products1, 20.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
+        repository.savePurchase(CLIENT_ID, STORE_ID, products2, 15.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
+        repository.savePurchase(CLIENT_ID, "store456", products1, 20.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
+        repository.savePurchase("client456", STORE_ID, products1, 20.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
+
         // Get the client-store receipts
         List<Receipt> clientStoreReceipts = repository.getClientStoreReceipts(CLIENT_ID, STORE_ID);
         
@@ -176,8 +178,8 @@ public class MemoryReceiptRepositoryTest {
         Map<Product, Pair<Integer, Double>> products = new HashMap<>();
         products.put(createProduct("product1", "Product 1"), new Pair<>(2, 10.0));
         
-        repository.savePurchase(CLIENT_ID, STORE_ID, products, 20.0, PAYMENT_DETAILS);
-        repository.savePurchase("client456", "store456", products, 20.0, PAYMENT_DETAILS);
+        repository.savePurchase(CLIENT_ID, STORE_ID, products, 20.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
+        repository.savePurchase("client456", "store456", products, 20.0, PAYMENT_DETAILS, SUPPLY_DETAILS);
         
         // Verify receipts were saved
         assertFalse(repository.getClientReceipts(CLIENT_ID).isEmpty());

--- a/src/test/java/ShoppingServiceTest.java
+++ b/src/test/java/ShoppingServiceTest.java
@@ -874,6 +874,10 @@ public class ShoppingServiceTest {
         anyDouble()   // amount
         )).thenReturn(new Response<>(10000));  // Replace 10000 with the desired mocked value
 
+        when(mockSupplyService.supplyOrder(
+            anyString(), anyString(), anyString(), anyString(), anyString()
+        )).thenReturn(new Response<>(10000)); // fake transaction ID
+
         MarketService marketService = serviceManager.getMarketService();
         // Step 1: Member makes offer
         PaymentDetailsDTO paymentDetails = new PaymentDetailsDTO(

--- a/src/test/java/ShoppingServiceTest.java
+++ b/src/test/java/ShoppingServiceTest.java
@@ -44,12 +44,14 @@ import Application.DTOs.ItemPriceBreakdownDTO;
 import Application.DTOs.OfferDTO;
 import Application.DTOs.PaymentDetailsDTO;
 import Application.DTOs.ShoppingBasketDTO;
+import Application.DTOs.SupplyDetailsDTO;
 import Application.DTOs.UserDTO;
 import Application.utils.Error;
 import Application.utils.Response;
 
 import Domain.ExternalServices.IExternalPaymentService;
 import Domain.ExternalServices.INotificationService;
+import Domain.Shopping.SupplyDetails;
 import Domain.management.PermissionType;
 
 import Domain.FacadeManager;
@@ -510,13 +512,16 @@ public class ShoppingServiceTest {
             long transactionId = 12345L;
             String clientName = "John Doe";
             String deliveryAddress = "123 Main St";
+            String city = "Test City";
+            String country = "Test Country";
+            String zip = "12345";
             String auctionEndDate = "2077-01-01 07:00";
             Response<AuctionDTO> res = storeService.addAuction(clientToken, store_id, product_id, auctionEndDate.toString(), 49.99f);
             mockAuctionId = res.getValue().getAuctionId();
             
             Response<Boolean> response = shoppingService.makeBid(
                 mockAuctionId, clientToken, validBidPrice,
-                cardNumber, expiryDate, cvv, transactionId, clientName, deliveryAddress
+                cardNumber, expiryDate, cvv, transactionId, clientName, deliveryAddress, city, country, zip
             );
             
             assertFalse("Valid bid should be accepted", response.errorOccurred());
@@ -526,7 +531,7 @@ public class ShoppingServiceTest {
             float lowBidPrice = 40.0f;
             Response<Boolean> lowBidResponse = shoppingService.makeBid(
                 mockAuctionId, clientToken, lowBidPrice,
-                cardNumber, expiryDate, cvv, transactionId, clientName, deliveryAddress
+                cardNumber, expiryDate, cvv, transactionId, clientName, deliveryAddress, city, country, zip
             );
             
             assertTrue("Low bid should be rejected", lowBidResponse.errorOccurred());
@@ -551,12 +556,15 @@ public class ShoppingServiceTest {
             String clientName = "John Doe";
             String auctionEndDate = "2077-01-01 07:00";
             String deliveryAddress = "123 Main St";
+            String city = "Test City";
+            String country = "Test Country";
+            String zip = "12345";
             
             mockAuctionId = storeService.addAuction(clientToken, store_id, product_id, auctionEndDate.toString(), 101.0).getValue().getAuctionId();
             
             Response<Boolean> response = shoppingService.makeBid(
                 mockAuctionId, clientToken, lowBidPrice,
-                cardNumber, expiryDate, cvv, transactionId, clientName, deliveryAddress
+                cardNumber, expiryDate, cvv, transactionId, clientName, deliveryAddress, city, country, zip
             );
             
             assertTrue("Should have error for low bid price", response.errorOccurred());
@@ -570,7 +578,7 @@ public class ShoppingServiceTest {
             float highBidPrice = 200.0f;
             Response<Boolean> highBidResponse = shoppingService.makeBid(
                 mockAuctionId, clientToken, highBidPrice,
-                cardNumber, expiryDate, cvv, transactionId, clientName, deliveryAddress
+                cardNumber, expiryDate, cvv, transactionId, clientName, deliveryAddress, city, country, zip
             );
             
             assertFalse("Higher bid should be accepted", highBidResponse.errorOccurred());
@@ -806,13 +814,22 @@ public class ShoppingServiceTest {
             "Offer Tester"                     // card holder name
         );
 
+        SupplyDetailsDTO supplyDetails = new SupplyDetailsDTO(
+            "123 Main St",                     // delivery address
+            "Test City",                        // city
+            "Test Country",                     // country
+            "12345",                             // zip code
+            "Offer Tester"                     // card holder name
+        );
+
         // Step 2: Call makeOffer
         Response<OfferDTO> response = shoppingService.makeOffer(
             clientToken,
             store_id,
             product_id,
             8.99,               // new proposed price
-            paymentDetails
+            paymentDetails,
+            supplyDetails
         );
 
         // Step 3: Assertions
@@ -827,7 +844,8 @@ public class ShoppingServiceTest {
     @Test
     public void testMakeOffer_ValidInput_ReturnsOfferDTO() {
         PaymentDetailsDTO paymentDetails = new PaymentDetailsDTO(user.getId(), "4111111111111111", LocalDate.now().plusYears(1), "123", "Offer Tester");
-        Response<OfferDTO> response = shoppingService.makeOffer(clientToken, store_id, product_id, 7.77, paymentDetails);
+        SupplyDetailsDTO supplyDetails = new SupplyDetailsDTO("123 Main St", "Test City", "Test Country", "12345", "Offer Tester");
+        Response<OfferDTO> response = shoppingService.makeOffer(clientToken, store_id, product_id, 7.77, paymentDetails, supplyDetails);
 
         assertFalse(response.errorOccurred());
         assertNotNull(response.getValue());
@@ -838,7 +856,8 @@ public class ShoppingServiceTest {
     @Test
     public void testMakeOffer_InvalidToken_ReturnsError() {
         PaymentDetailsDTO paymentDetails = new PaymentDetailsDTO(user.getId(), "4111111111111111", LocalDate.now().plusYears(1), "123", "Offer Tester");
-        Response<OfferDTO> response = shoppingService.makeOffer("invalidToken", store_id, product_id, 9.99, paymentDetails);
+        SupplyDetailsDTO supplyDetails = new SupplyDetailsDTO("123 Main St", "Test City", "Test Country", "12345", "Offer Tester");
+        Response<OfferDTO> response = shoppingService.makeOffer("invalidToken", store_id, product_id, 9.99, paymentDetails, supplyDetails);
 
         assertTrue(response.errorOccurred());
         assertEquals("Invalid token", response.getErrorMessage());
@@ -865,8 +884,16 @@ public class ShoppingServiceTest {
             "Offer Tester"
         );
 
+        SupplyDetailsDTO supplyDetails = new SupplyDetailsDTO(
+            "123 Main St",
+            "Test City",
+            "Test Country",
+            "12345",
+            "Offer Tester"
+        );
+
         Response<OfferDTO> offerResponse = shoppingService.makeOffer(
-            clientToken, store_id, product_id, 5.55, paymentDetails
+            clientToken, store_id, product_id, 5.55, paymentDetails, supplyDetails
         );
 
         assertFalse("Offer creation should succeed", offerResponse.errorOccurred());
@@ -1242,7 +1269,8 @@ public class ShoppingServiceTest {
     @Test
     public void testGetAllOffersOfUser_Success() {
         PaymentDetailsDTO paymentDetails = new PaymentDetailsDTO(user.getId(), "4111111111111111", LocalDate.now().plusYears(1), "123", "Offer Tester");
-        shoppingService.makeOffer(clientToken, store_id, product_id, 11.11, paymentDetails);
+        SupplyDetailsDTO supplyDetails = new SupplyDetailsDTO("123 Main St", "Test City", "Test Country", "12345", "Offer Tester");
+        shoppingService.makeOffer(clientToken, store_id, product_id, 11.11, paymentDetails, supplyDetails);
 
         Response<List<OfferDTO>> response = shoppingService.getAllOffersOfUser(clientToken);
         assertFalse(response.errorOccurred());
@@ -1261,7 +1289,8 @@ public class ShoppingServiceTest {
     @Test
     public void testCounterOffer_ValidInput_ReturnsUpdatedOffer() {
         PaymentDetailsDTO paymentDetails = new PaymentDetailsDTO(user.getId(), "4111111111111111", LocalDate.now().plusYears(1), "123", "Offer Tester");
-        OfferDTO offer = shoppingService.makeOffer(clientToken, store_id, product_id, 6.66, paymentDetails).getValue();
+        SupplyDetailsDTO supplyDetails = new SupplyDetailsDTO("123 Main St", "Test City", "Test Country", "12345", "Offer Tester");
+        OfferDTO offer = shoppingService.makeOffer(clientToken, store_id, product_id, 6.66, paymentDetails, supplyDetails).getValue();
         Response<OfferDTO> counterResponse = shoppingService.counterOffer(clientToken, offer.getId(), 7.77);
 
         assertFalse(counterResponse.errorOccurred());

--- a/src/test/java/StoreTests/StoreFacadeTests.java
+++ b/src/test/java/StoreTests/StoreFacadeTests.java
@@ -634,6 +634,10 @@ public class StoreFacadeTests {
         when(auction.getCvv()).thenReturn(cvv);
         when(auction.getClientName()).thenReturn(clientName);
         when(auction.getCurrentPrice()).thenReturn(currentPrice);
+        when((auction.getDeliveryAddress())).thenReturn(address);
+        when(auction.getCity()).thenReturn(city);
+        when(auction.getCountry()).thenReturn(country);
+        when(auction.getZipCode()).thenReturn(zip);
         when(auctionRepository.remove(auctionId)).thenReturn(auction);
 
         // Stubbing store

--- a/src/test/java/StoreTests/StoreServiceTests.java
+++ b/src/test/java/StoreTests/StoreServiceTests.java
@@ -74,9 +74,19 @@ public class StoreServiceTests {
         when(mockPaymentService.cancelPayment(anyInt())).thenReturn(new Response<>(true));
         when(mockPaymentService.handshake()).thenReturn(new Response<>(true));
         when(mockPaymentService.updatePaymentServiceURL(anyString())).thenReturn(new Response<>());
+
+        IExternalSupplyService mockSupplyService = mock(IExternalSupplyService.class);
+
+        when(mockSupplyService.supplyOrder(
+                anyString(), anyString(), anyString(), anyString(), anyString()
+        )).thenReturn(new Response<>(1234)); // fake transaction ID
+
+        when(mockSupplyService.cancelSupply(anyInt())).thenReturn(new Response<>(true));
+        when(mockSupplyService.handshake()).thenReturn(new Response<>(true));
+        when(mockSupplyService.updateSupplyServiceURL(anyString())).thenReturn(new Response<>());
         
         // Initialize facade manager
-        FacadeManager facadeManager = new FacadeManager(repositoryManager, mockPaymentService, mock(IExternalSupplyService.class));
+        FacadeManager facadeManager = new FacadeManager(repositoryManager, mockPaymentService, mockSupplyService);
 
         // Initialize service manager and store as a field for use across tests
         this.serviceManager = new ServiceManager(facadeManager);
@@ -1142,7 +1152,7 @@ public class StoreServiceTests {
             "Test City",
             "Test Country",
             "12345",
-            "Offer Tester"
+            "Buyer"
         );
         Response<OfferDTO> offerResponse = shoppingService.makeOffer(buyerToken, storeId, productId, 100.0, payment, supply);
         String offerId = offerResponse.getValue().getId();

--- a/src/test/java/StoreTests/StoreServiceTests.java
+++ b/src/test/java/StoreTests/StoreServiceTests.java
@@ -39,6 +39,7 @@ import Application.DTOs.OfferDTO;
 import Application.DTOs.PaymentDetailsDTO;
 import Application.DTOs.ProductDTO;
 import Application.DTOs.StoreDTO;
+import Application.DTOs.SupplyDetailsDTO;
 import Application.DTOs.UserDTO;
 import Application.utils.Response;
 import Domain.ExternalServices.IExternalPaymentService;
@@ -1043,7 +1044,14 @@ public class StoreServiceTests {
             "321",
             "Reject User"
         );
-        Response<OfferDTO> offerResponse = shoppingService.makeOffer(buyerToken, storeId, productId, 90.0, payment);
+        SupplyDetailsDTO supply = new SupplyDetailsDTO(
+            "123 Main St",
+            "Test City",
+            "Test Country",
+            "12345",
+            "Reject User"
+        );
+        Response<OfferDTO> offerResponse = shoppingService.makeOffer(buyerToken, storeId, productId, 90.0, payment, supply);
         assertFalse("Making offer should succeed", offerResponse.errorOccurred());
 
         // Reject the offer
@@ -1083,7 +1091,8 @@ public class StoreServiceTests {
         Response<UserDTO> buyer = userService.register(guestBuyer.getValue().getSessionToken(), "Buyer1", "Pass1!word", "buyer@store.com");
         String buyerToken = buyer.getValue().getSessionToken();
         PaymentDetailsDTO payment = new PaymentDetailsDTO(buyer.getValue().getId(), "4111111111111111", LocalDate.now().plusYears(1), "123", "Buyer");
-        Response<OfferDTO> offerResponse = shoppingService.makeOffer(buyerToken, storeId, productId, 100.0, payment);
+        SupplyDetailsDTO supply = new SupplyDetailsDTO("123 Main St", "Test City", "Test Country", "12345", "Offer Tester");
+        Response<OfferDTO> offerResponse = shoppingService.makeOffer(buyerToken, storeId, productId, 100.0, payment, supply);
         String offerId = offerResponse.getValue().getId();
 
         // First manager approves
@@ -1128,7 +1137,14 @@ public class StoreServiceTests {
 
         PaymentDetailsDTO payment = new PaymentDetailsDTO(
             buyer.getValue().getId(), "4111111111111111", LocalDate.now().plusYears(1), "123", "Buyer");
-        Response<OfferDTO> offerResponse = shoppingService.makeOffer(buyerToken, storeId, productId, 100.0, payment);
+        SupplyDetailsDTO supply = new SupplyDetailsDTO(
+            "123 Main St",
+            "Test City",
+            "Test Country",
+            "12345",
+            "Offer Tester"
+        );
+        Response<OfferDTO> offerResponse = shoppingService.makeOffer(buyerToken, storeId, productId, 100.0, payment, supply);
         String offerId = offerResponse.getValue().getId();
 
         // First manager approves
@@ -1161,7 +1177,8 @@ public class StoreServiceTests {
         String buyerToken = buyer.getValue().getSessionToken();
 
         PaymentDetailsDTO payment = new PaymentDetailsDTO(buyer.getValue().getId(), "4111111111111111", LocalDate.now().plusYears(1), "123", "Reject User");
-        Response<OfferDTO> offerResponse = shoppingService.makeOffer(buyerToken, storeId, productId, 180.0, payment);
+        SupplyDetailsDTO supply = new SupplyDetailsDTO("123 Main St", "Test City", "Test Country", "12345", "Reject User");
+        Response<OfferDTO> offerResponse = shoppingService.makeOffer(buyerToken, storeId, productId, 180.0, payment, supply);
         String offerId = offerResponse.getValue().getId();
 
         Response<OfferDTO> result = storeService.rejectOffer(tokenId, offerId);
@@ -1194,7 +1211,8 @@ public class StoreServiceTests {
         String buyerToken = buyer.getValue().getSessionToken();
 
         PaymentDetailsDTO payment = new PaymentDetailsDTO(buyer.getValue().getId(), "4111111111111111", LocalDate.now().plusYears(1), "321", "Counter Buyer");
-        Response<OfferDTO> offerResponse = shoppingService.makeOffer(buyerToken, storeId, productId, 190.0, payment);
+        SupplyDetailsDTO supply = new SupplyDetailsDTO("123 Main St", "Test City", "Test Country", "12345", "Counter Buyer");
+        Response<OfferDTO> offerResponse = shoppingService.makeOffer(buyerToken, storeId, productId, 190.0, payment, supply);
         String offerId = offerResponse.getValue().getId();
 
         Response<OfferDTO> result = storeService.counterOffer(tokenId, offerId, 220.0);


### PR DESCRIPTION
closes #444

## Summary by Sourcery

Integrate external supply service into auction bidding and offer workflows by capturing and persisting delivery details and invoking supplyOrder in domain and application layers with proper error handling.

New Features:
- Introduce SupplyDetails and SupplyDetailsDTO to represent delivery address, city, country, and zip code.
- Inject and invoke IExternalSupplyService.supplyOrder in acceptBid and offer processing to fulfill supply orders.

Bug Fixes:
- Handle rollback and cancellation for supply failures alongside payment failures in StoreFacade.acceptBid and OfferManager.

Enhancements:
- Extend Auction, Offer, and Receipt entities to store supply details alongside payment information.
- Update StoreFacade, OfferManager, ShoppingService, StoreService, ShoppingCartFacade, and PurchasePresenter to accept and propagate supply details.
- Augment UI dialogs (MakeOfferDialog, HomePageView) to collect delivery details and pass them through service calls.
- Modify ReceiptRepository, ReceiptBuilder, JpaReceiptRepository, and MemoryReceiptRepository to persist supplyDetails with receipts.

Build:
- Switch default Spring profile from dev to prod in application.properties.

Tests:
- Update unit tests across ShoppingServiceTest, StoreFacadeTests, StoreServiceTests, ExternalServiceTest, and Receipt tests to include supply details and mock supplyService behavior.