### PR TITLE
finished null id bug

### DIFF
--- a/src/main/java/Domain/Store/Discounts/DiscountBuilder.java
+++ b/src/main/java/Domain/Store/Discounts/DiscountBuilder.java
@@ -57,7 +57,7 @@ public class DiscountBuilder {
         }
         discountDTO.setStoreId(storeId);
         
-        Condition cond = conditionBuilder.buildCondition(discountDTO.getCondition());
+        Condition cond = conditionBuilder.buildConditionWithId(discountDTO.getCondition(), UUID.randomUUID().toString());
         
         switch(discountDTO.getType()) {
             case SIMPLE:

--- a/src/main/java/UI/views/ManagerView.java
+++ b/src/main/java/UI/views/ManagerView.java
@@ -908,6 +908,7 @@ public class ManagerView extends BaseView implements BeforeEnterObserver {
         if (sessionToken == null) {
             Notification.show("Access denied. Please log in.", 4000, Notification.Position.MIDDLE);
             event.forwardTo("");
+            return;
         }
         if (currentStoreId == null) {
             Notification.show("Please select a store first", 3000, Notification.Position.MIDDLE);

--- a/src/test/java/Domain/Store/Discounts/DiscountBuilderTest.java
+++ b/src/test/java/Domain/Store/Discounts/DiscountBuilderTest.java
@@ -1,6 +1,9 @@
 package Domain.Store.Discounts;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import org.junit.Before;
@@ -76,7 +79,7 @@ public class DiscountBuilderTest {
         Application.DTOs.ConditionDTO conditionDTO = new Application.DTOs.ConditionDTO();
         dto.setCondition(conditionDTO);
         
-        when(mockConditionBuilder.buildCondition(conditionDTO)).thenReturn(mockCondition);
+        when(mockConditionBuilder.buildConditionWithId(eq(conditionDTO), anyString())).thenReturn(mockCondition);
         
         Discount discount = discountBuilder.buildDiscount(dto, "test-id", TEST_STORE_ID);
         
@@ -99,7 +102,7 @@ public class DiscountBuilderTest {
         Application.DTOs.ConditionDTO conditionDTO = new Application.DTOs.ConditionDTO();
         dto.setCondition(conditionDTO);
         
-        when(mockConditionBuilder.buildCondition(conditionDTO)).thenReturn(mockCondition);
+        when(mockConditionBuilder.buildConditionWithId(eq(conditionDTO), anyString())).thenReturn(mockCondition);
         
         // Test the single-parameter method that generates UUID
         Discount discount = discountBuilder.buildDiscount(dto);
@@ -138,7 +141,7 @@ public class DiscountBuilderTest {
         Application.DTOs.ConditionDTO conditionDTO = new Application.DTOs.ConditionDTO();
         dto.setCondition(conditionDTO);
         
-        when(mockConditionBuilder.buildCondition(any())).thenReturn(mockCondition);
+        when(mockConditionBuilder.buildConditionWithId(any(), anyString())).thenReturn(mockCondition);
         
         Discount discount = discountBuilder.buildDiscount(dto, "and-test-id", TEST_STORE_ID);
         
@@ -169,7 +172,7 @@ public class DiscountBuilderTest {
         Application.DTOs.ConditionDTO conditionDTO = new Application.DTOs.ConditionDTO();
         dto.setCondition(conditionDTO);
         
-        when(mockConditionBuilder.buildCondition(any())).thenReturn(mockCondition);
+        when(mockConditionBuilder.buildConditionWithId(any(), anyString())).thenReturn(mockCondition);
         
         Discount discount = discountBuilder.buildDiscount(dto, "or-test-id", TEST_STORE_ID);
         
@@ -207,7 +210,7 @@ public class DiscountBuilderTest {
         Application.DTOs.ConditionDTO conditionDTO = new Application.DTOs.ConditionDTO();
         dto.setCondition(conditionDTO);
         
-        when(mockConditionBuilder.buildCondition(any())).thenReturn(mockCondition);
+        when(mockConditionBuilder.buildConditionWithId(eq(conditionDTO), anyString())).thenReturn(mockCondition);
         
         Discount discount = discountBuilder.buildDiscount(dto, "xor-test-id", TEST_STORE_ID);
         
@@ -275,7 +278,7 @@ public class DiscountBuilderTest {
         Application.DTOs.ConditionDTO conditionDTO = new Application.DTOs.ConditionDTO();
         dto.setCondition(conditionDTO);
         
-        when(mockConditionBuilder.buildCondition(any())).thenReturn(mockCondition);
+        when(mockConditionBuilder.buildConditionWithId(any(), anyString())).thenReturn(mockCondition);
         
         String newStoreId = "new-store-123";
         Discount discount = discountBuilder.buildDiscount(dto, "test-id", newStoreId);


### PR DESCRIPTION
## Summary by Sourcery

Fix null ID assignment for discount conditions and prevent further execution after access denial in manager view

Bug Fixes:
- Assign a random UUID when building discount conditions to avoid null IDs
- Add early return after forwarding unauthenticated users to login in ManagerView.beforeEnter